### PR TITLE
feat: #63 new Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all up down clean fclean re logs ps windows check build-backend build-frontend
+.PHONY: all up down clean fclean re logs ps windows check build-backend build-frontend down-backend down-frontend re-backend re-frontend
 
 all: up
 
@@ -34,3 +34,13 @@ build-backend:
 
 build-frontend:
 	docker compose up --build -d frontend
+
+down-backend:
+	docker compose stop backend && docker compose rm -f backend
+
+down-frontend:
+	docker compose stop frontend && docker compose rm -f frontend
+
+re-backend: down-backend build-backend
+
+re-frontend: down-frontend build-frontend

--- a/docs/DEV_DOC.md
+++ b/docs/DEV_DOC.md
@@ -121,6 +121,10 @@ All commands run from the **repository root**.
 | `make windows` | Same as `make` — for GNU Make on Windows (Git Bash/WSL) |
 | `make build-backend` | Rebuild and restart the backend container only |
 | `make build-frontend` | Rebuild and restart the frontend container only |
+| `make down-backend` | Stop and remove the backend container only |
+| `make down-frontend` | Stop and remove the frontend container only |
+| `make re-backend` | `down-backend` then `build-backend` — fast backend iteration |
+| `make re-frontend` | `down-frontend` then `build-frontend` — fast frontend iteration |
 
 **Windows users (no GNU Make):**
 
@@ -186,6 +190,7 @@ make build-frontend
 
 > `make build-backend` / `make build-frontend` are only needed when **adding new packages**.
 > For regular code edits, live reload picks up changes automatically — see [Live Reload](#live-reload) below.
+> Use `make re-backend` / `make re-frontend` when you need a **full container reset** (e.g. environment variable changes, broken container state).
 
 ---
 


### PR DESCRIPTION
# New Makefile targets:
- `make down-backend` : to stop backend containers
- `make down-frontend` : to stop fronted containers
- `make re-backend` : to stop and rebuild backend containers
- `make re-frontend` : to stop and rebuild frontend containers