### PR TITLE
feat: #99 save users on first-login, added endpoint with access_token

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,9 @@ DB_PASSWORD=change_me
 DB_NAME=transcendence_db
 DB_ECHO=true
 
+# Auth
+JWT_SECRET_KEY=change_me
+
 # Backend microservices
 USER_SERVICE_PORT=8001
 GAME_SERVICE_PORT=8002

--- a/src/backend/request.http
+++ b/src/backend/request.http
@@ -27,6 +27,11 @@ content-type: application/json
     "username": "maurodri",
     "password": "maurodri123"
 }
+
+### Me (replace <token> with the access_token from login response)
+GET https://localhost:8443/api/users/auth/me HTTP/1.1
+Authorization: Bearer <token>
+
 ### Register
 POST https://localhost:8443/api/users/auth/register HTTP/1.1
 content-type: application/json

--- a/src/backend/shared/config/settings.py
+++ b/src/backend/shared/config/settings.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     DB_PORT: int = 5432
     DB_NAME: str = "transcendence_db"
     DB_ECHO: bool = False
+    JWT_SECRET_KEY: str = "changeme"
 
     @property
     def SQLALCHEMY_DATABASE_URI(self) -> str:

--- a/src/backend/user-service/alembic/versions/20260324_replace_email_with_credential_id_in_users.py
+++ b/src/backend/user-service/alembic/versions/20260324_replace_email_with_credential_id_in_users.py
@@ -1,0 +1,35 @@
+"""replace email with credential_id in users table
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-03-24
+"""
+from typing import Union
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = 'f6a7b8c9d0e1'
+down_revision: Union[str, None] = 'e5f6a7b8c9d0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column('users', 'email')
+    op.add_column('users', sa.Column(
+        'credential_id',
+        sa.Integer(),
+        sa.ForeignKey('credentials.id'),
+        nullable=True,
+        unique=True,
+    ))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'credential_id')
+    op.add_column('users', sa.Column(
+        'email',
+        sa.String(100),
+        nullable=True,
+        unique=True,
+    ))

--- a/src/backend/user-service/main.py
+++ b/src/backend/user-service/main.py
@@ -3,12 +3,14 @@ from typing import Annotated
 from fastapi import FastAPI, status, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
 from service.schemas import (
     Login, LoginResponse, RegisterRequest, RegisterResponse,
-    ProfileResponse, UpdateProfileRequest,
+    ProfileResponse, UpdateProfileRequest, MeResponse,
     FriendResponse, FriendRequestResponse,
 )
-from service.service import authenticate, register_credentials, get_profile, update_profile
+from service.service import authenticate, register_credentials, get_profile, update_profile, get_me
 from service.friends import (
     get_friends, get_pending_requests, get_sent_requests, send_friend_request,
     accept_friend_request, delete_friendship, search_users,
@@ -16,6 +18,7 @@ from service.friends import (
 from shared.database import get_db
 
 SessionDependency = Annotated[AsyncSession, Depends(get_db)]
+bearer_scheme = HTTPBearer()
 
 app = FastAPI(title="User Service")
 
@@ -33,6 +36,14 @@ def root():
 @app.post("/auth/login", status_code=status.HTTP_200_OK, response_model=LoginResponse)
 async def login(login: Login, session: SessionDependency):
     return await authenticate(login, session)
+
+
+@app.get("/auth/me", response_model=MeResponse)
+async def me(
+    session: SessionDependency,
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+):
+    return await get_me(credentials.credentials, session)
 
 
 @app.post("/auth/register", status_code=status.HTTP_201_CREATED, response_model=RegisterResponse)

--- a/src/backend/user-service/models/user.py
+++ b/src/backend/user-service/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, TIMESTAMP, Boolean
+from sqlalchemy import Column, ForeignKey, Integer, String, TIMESTAMP, Boolean
 from sqlalchemy.sql import func
 
 from shared.database import Base
@@ -7,9 +7,9 @@ from shared.database import Base
 class User(Base):
     __tablename__ = "users"
 
-    id           = Column(Integer, primary_key=True, index=True)
-    username     = Column(String(50), unique=True, nullable=False)
-    email        = Column(String(100), unique=True)
+    id            = Column(Integer, primary_key=True, index=True)
+    username      = Column(String(50), unique=True, nullable=False)
+    credential_id = Column(Integer, ForeignKey("credentials.id"), unique=True, nullable=True)
     password_hash = Column(String)
     status       = Column(String(20), default="offline")
     avatar_url   = Column(String, nullable=True)

--- a/src/backend/user-service/schemas.py
+++ b/src/backend/user-service/schemas.py
@@ -37,6 +37,20 @@ class ProfileResponse(BaseModel):
     dark_mode:    bool = False
 
 
+class MeResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id:            int
+    username:      str
+    credential_id: Optional[int] = None
+    display_name:  Optional[str] = None
+    status:        str
+    avatar_url:    Optional[str] = None
+    created_at:    Optional[datetime] = None
+    bio:           Optional[str] = None
+    dark_mode:     bool = False
+
+
 class UpdateProfileRequest(BaseModel):
     display_name: Optional[str] = None
     bio:          Optional[str] = None

--- a/src/backend/user-service/service.py
+++ b/src/backend/user-service/service.py
@@ -6,12 +6,12 @@ from datetime import datetime, timedelta, timezone
 import bcrypt
 import hashlib
 import secrets
-from jose import jwt
+from jose import jwt, ExpiredSignatureError, JWTError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from shared.config.settings import settings
 
-SECRET_KEY = "secret"
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
@@ -20,7 +20,7 @@ def create_access_token(data: dict, expires_delta: timedelta):
     to_encode = data.copy()
     expire = datetime.now(timezone.utc) + expires_delta
     to_encode.update({"exp": expire})
-    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return jwt.encode(to_encode, settings.JWT_SECRET_KEY, algorithm=ALGORITHM)
 
 
 def hash_password(password: str) -> bytes:
@@ -60,7 +60,6 @@ async def authenticate(login: Login, session: AsyncSession) -> LoginResponse:
         user = User(
             username=credential.username,
             credential_id=credential.id,
-            password_hash=credential.password,
         )
         session.add(user)
 
@@ -106,11 +105,16 @@ async def get_profile(user_id: int, session: AsyncSession) -> User | None:
 
 async def get_me(token: str, session: AsyncSession) -> MeResponse:
     try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=[ALGORITHM])
         username: str = payload.get("sub")
         if username is None:
-            raise ValueError("missing sub")
-    except Exception as exc:
+            raise JWTError("missing sub")
+    except ExpiredSignatureError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token expired",
+        ) from exc
+    except JWTError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid token",

--- a/src/backend/user-service/service.py
+++ b/src/backend/user-service/service.py
@@ -1,5 +1,5 @@
 from fastapi import status, HTTPException
-from service.schemas import Login, LoginResponse, RegisterRequest, RegisterResponse, UpdateProfileRequest
+from service.schemas import Login, LoginResponse, RegisterRequest, RegisterResponse, UpdateProfileRequest, MeResponse
 from service.models.credentials import Credentials, Tokens
 from service.models.user import User
 from datetime import datetime, timedelta, timezone
@@ -46,16 +46,26 @@ async def authenticate(login: Login, session: AsyncSession) -> LoginResponse:
     )
     raw_refresh_token = secrets.token_hex(32)
     refresh_token_hash = hashlib.sha256(raw_refresh_token.encode()).hexdigest()
-    tokens = Tokens(
-        credential_id=credential.id,
-        token_type="bearer",
-        refresh_token_hash=refresh_token_hash,
-        expires_at=datetime.now(timezone.utc) + timedelta(days=30),
-    )
-    session.add(tokens)
-    await session.commit()
-    user_row = await session.execute(select(User).where(User.username == credential.username))
+    token_row = await session.execute(select(Tokens).where(Tokens.credential_id == credential.id))
+    tokens = token_row.scalars().first()
+    if tokens is None:
+        tokens = Tokens(credential_id=credential.id, token_type="bearer")
+        session.add(tokens)
+    tokens.refresh_token_hash = refresh_token_hash
+    tokens.expires_at = datetime.now(timezone.utc) + timedelta(days=30)
+
+    user_row = await session.execute(select(User).where(User.credential_id == credential.id))
     user = user_row.scalars().first()
+    if user is None:
+        user = User(
+            username=credential.username,
+            credential_id=credential.id,
+            password_hash=credential.password,
+        )
+        session.add(user)
+
+    await session.commit()
+    await session.refresh(user)
     return LoginResponse(
         access_token=access_token,
         token_type="bearer",
@@ -80,18 +90,40 @@ async def register_credentials(register_request: RegisterRequest, session: Async
         session.add(credentials)
         await session.commit()
         await session.refresh(credentials)
-    except IntegrityError:
+    except IntegrityError as exc:
         await session.rollback()
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="User already exists"
-        )
+        ) from exc
     return RegisterResponse(username=credentials.username)
 
 
 async def get_profile(user_id: int, session: AsyncSession) -> User | None:
     result = await session.execute(select(User).where(User.id == user_id))
     return result.scalars().first()
+
+
+async def get_me(token: str, session: AsyncSession) -> MeResponse:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise ValueError("missing sub")
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+        ) from exc
+    result = await session.execute(select(Credentials).where(Credentials.username == username))
+    credential = result.scalars().first()
+    if credential is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    user_row = await session.execute(select(User).where(User.credential_id == credential.id))
+    user = user_row.scalars().first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return user
 
 
 async def update_profile(

--- a/src/backend/user-service/tests/test_authenticate.py
+++ b/src/backend/user-service/tests/test_authenticate.py
@@ -1,0 +1,130 @@
+# src/backend/user-service/tests/test_authenticate.py
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import bcrypt
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from service.main import app
+
+
+def _hashed(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+
+
+def _make_credential(username: str = "alice", password: str = "secret123"):
+    cred = MagicMock()
+    cred.id = 1
+    cred.username = username
+    cred.password = _hashed(password)
+    return cred
+
+
+def _make_user(credential_id: int = 1, user_id: int = 42):
+    user = MagicMock()
+    user.id = user_id
+    user.credential_id = credential_id
+    user.username = "alice"
+    user.password_hash = None
+    return user
+
+
+def _make_token_row(credential_id: int = 1):
+    token = MagicMock()
+    token.credential_id = credential_id
+    token.refresh_token_hash = "oldhash"
+    return token
+
+
+def _session_returning(*call_results):
+    """Build a mock AsyncSession whose execute() returns call_results in order."""
+    session = AsyncMock()
+    sides = []
+    for obj in call_results:
+        scalars_mock = MagicMock()
+        scalars_mock.first.return_value = obj
+        result_mock = MagicMock()
+        result_mock.scalars.return_value = scalars_mock
+        sides.append(result_mock)
+    session.execute.side_effect = sides
+    return session
+
+
+@pytest.mark.asyncio
+async def test_first_login_creates_user_linked_to_credential():
+    """First login: no existing User row → one is created with credential_id set."""
+    cred = _make_credential()
+    # execute calls: 1=credentials, 2=tokens (None → new), 3=user (None → new)
+    session = _session_returning(cred, None, None)
+
+    new_user = _make_user()
+    session.refresh = AsyncMock(side_effect=lambda obj: setattr(obj, "id", new_user.id) or None)
+
+    added_objects = []
+    session.add = MagicMock(side_effect=added_objects.append)
+
+    from shared.database import get_db
+
+    async def _fake_db():
+        yield session
+
+    app.dependency_overrides[get_db] = _fake_db
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/auth/login", json={"username": "alice", "password": "secret123"})
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "access_token" in data
+    assert "refresh_token" in data
+
+    # A User object must have been added to the session
+    from service.models.user import User
+    created_users = [o for o in added_objects if isinstance(o, User)]
+    assert len(created_users) == 1
+    assert created_users[0].credential_id == cred.id
+    assert created_users[0].username == cred.username
+    # password_hash must NOT be copied from credentials
+    assert created_users[0].password_hash is None
+
+
+@pytest.mark.asyncio
+async def test_subsequent_login_updates_token_not_duplicates():
+    """Second login: existing Tokens row is updated in-place, no new row added."""
+    cred = _make_credential()
+    existing_token = _make_token_row(credential_id=cred.id)
+    existing_user = _make_user(credential_id=cred.id)
+    # execute calls: 1=credentials, 2=tokens (found), 3=user (found)
+    session = _session_returning(cred, existing_token, existing_user)
+    session.refresh = AsyncMock()
+
+    added_objects = []
+    session.add = MagicMock(side_effect=added_objects.append)
+
+    from shared.database import get_db
+
+    async def _fake_db():
+        yield session
+
+    app.dependency_overrides[get_db] = _fake_db
+
+    old_hash = existing_token.refresh_token_hash
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            resp = await client.post("/auth/login", json={"username": "alice", "password": "secret123"})
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200, resp.text
+
+    # No new Tokens row should have been added
+    from service.models.credentials import Tokens
+    added_tokens = [o for o in added_objects if isinstance(o, Tokens)]
+    assert len(added_tokens) == 0
+
+    # The existing token's hash must have been rotated
+    assert existing_token.refresh_token_hash != old_hash


### PR DESCRIPTION
Closes #99 

Important: 
- tokens are refreshed on authentication now instead of saved every time. 
- we have to decide if we will add users to the user table on the authenticate function, or the get_me function, so that it is added after token validation.