### PR TITLE
146 front protect authenticated routes with privateroute

### DIFF
--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import Profile from './pages/Profile'
 import ForgotPassword from './pages/ForgotPassword'
 import Chat from './pages/Chat'
 import PongCanvas from './Components/PongCanvas'
+import PrivateRoute from './Components/PrivateRoute'
 
 export default function App() {
   return (
@@ -21,9 +22,14 @@ export default function App() {
         <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/register" element={<Register />} />
         <Route path="/pong-develop" element={<PongCanvas />} />
-        {/* Route to the profile page; this page shows user information, settings
-            and match history. */}
-        <Route path="/profile" element={<Profile />} />
+        <Route
+          path="/profile"
+          element={(
+            <PrivateRoute>
+              <Profile />
+            </PrivateRoute>
+          )}
+        />
         <Route path="/forgot-password" element={<ForgotPassword />} />
         <Route path="/chat/:roomId" element={<Chat />} />
       </Routes>

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -22,6 +22,7 @@ export default function App() {
         <Route path="/leaderboard" element={<Leaderboard />} />
         <Route path="/register" element={<Register />} />
         <Route path="/pong-develop" element={<PongCanvas />} />
+
         <Route
           path="/profile"
           element={(
@@ -30,8 +31,17 @@ export default function App() {
             </PrivateRoute>
           )}
         />
+
+        <Route
+          path="/chat/:roomId"
+          element={(
+            <PrivateRoute>
+              <Chat />
+            </PrivateRoute>
+          )}
+        />
+
         <Route path="/forgot-password" element={<ForgotPassword />} />
-        <Route path="/chat/:roomId" element={<Chat />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/frontend/src/Components/AuthRequired.css
+++ b/src/frontend/src/Components/AuthRequired.css
@@ -1,0 +1,44 @@
+.auth-required-page {
+  min-height: calc(100vh - 80px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.auth-required-card {
+  width: 100%;
+  max-width: 520px;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 1rem;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.35);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
+}
+
+.auth-required-card h1 {
+  margin-bottom: 1rem;
+}
+
+.auth-required-card p {
+  margin-bottom: 1.5rem;
+}
+
+.auth-required-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  align-items: center;
+}
+
+.auth-required-button {
+  display: inline-block;
+  padding: 0.8rem 1.4rem;
+  border-radius: 0.6rem;
+  text-decoration: none;
+}
+
+.auth-required-link {
+  text-decoration: none;
+}

--- a/src/frontend/src/Components/AuthRequired.jsx
+++ b/src/frontend/src/Components/AuthRequired.jsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom'
+import NavbarComponent from './Navbar'
+import './AuthRequired.css'
+
+export default function AuthRequired() {
+  return (
+    <>
+      <NavbarComponent />
+
+      <main className="auth-required-page">
+        <section className="auth-required-card">
+          <h1>Private Area</h1>
+          <p>You must be logged in to access the Profile page.</p>
+
+          <div className="auth-required-actions">
+            <Link to="/login" className="auth-required-button">
+              Go to Login
+            </Link>
+
+            <Link to="/" className="auth-required-link">
+              Back to Home
+            </Link>
+          </div>
+        </section>
+      </main>
+    </>
+  )
+}

--- a/src/frontend/src/Components/AuthRequired.jsx
+++ b/src/frontend/src/Components/AuthRequired.jsx
@@ -1,6 +1,5 @@
 import { Link } from 'react-router-dom'
 import NavbarComponent from './Navbar'
-import './AuthRequired.css'
 
 export default function AuthRequired() {
   return (

--- a/src/frontend/src/Components/AuthRequired.jsx
+++ b/src/frontend/src/Components/AuthRequired.jsx
@@ -10,7 +10,7 @@ export default function AuthRequired() {
       <main className="auth-required-page">
         <section className="auth-required-card">
           <h1>Private Area</h1>
-          <p>You must be logged in to access the Profile page.</p>
+          <p>You must be logged in to access this page.</p>
 
           <div className="auth-required-actions">
             <Link to="/login" className="auth-required-button">

--- a/src/frontend/src/Components/PrivateRoute.jsx
+++ b/src/frontend/src/Components/PrivateRoute.jsx
@@ -1,0 +1,14 @@
+import { useAuth } from '../context/authContext'
+import AuthRequired from './AuthRequired'
+
+export default function PrivateRoute({ children }) {
+  const { isAuthenticated, isAuthReady } = useAuth()
+
+  if (!isAuthReady)
+    return null
+
+  if (!isAuthenticated)
+    return <AuthRequired />
+
+  return children
+}

--- a/src/frontend/src/Components/PrivateRoute.jsx
+++ b/src/frontend/src/Components/PrivateRoute.jsx
@@ -1,11 +1,32 @@
 import { useAuth } from '../context/authContext'
 import AuthRequired from './AuthRequired'
+import NavbarComponent from './Navbar'
+import './AuthRequired.css'
+
+function AuthLoading() {
+  return (
+    <>
+      <NavbarComponent />
+
+      <main className="auth-required-page">
+        <section
+          className="auth-required-card"
+          aria-busy="true"
+          aria-live="polite"
+        >
+          <h1>Loading</h1>
+          <p>Checking authentication status...</p>
+        </section>
+      </main>
+    </>
+  )
+}
 
 export default function PrivateRoute({ children }) {
   const { isAuthenticated, isAuthReady } = useAuth()
 
   if (!isAuthReady)
-    return null
+    return <AuthLoading />
 
   if (!isAuthenticated)
     return <AuthRequired />

--- a/src/frontend/src/Components/PrivateRoute.test.jsx
+++ b/src/frontend/src/Components/PrivateRoute.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { AuthContext } from '../context/authContext'
+import PrivateRoute from './PrivateRoute'
+
+function renderWithAuth(authValue) {
+  return render(
+    <MemoryRouter>
+      <AuthContext.Provider value={authValue}>
+        <PrivateRoute>
+          <div>protected content</div>
+        </PrivateRoute>
+      </AuthContext.Provider>
+    </MemoryRouter>
+  )
+}
+
+describe('PrivateRoute', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows loading state when auth is not ready', () => {
+    renderWithAuth({ isAuthReady: false, isAuthenticated: false })
+    expect(screen.getByText(/checking authentication status/i)).toBeInTheDocument()
+    expect(screen.queryByText('protected content')).not.toBeInTheDocument()
+  })
+
+  it('shows auth-required when ready but not authenticated', () => {
+    renderWithAuth({ isAuthReady: true, isAuthenticated: false })
+    expect(screen.getByText(/you must be logged in/i)).toBeInTheDocument()
+    expect(screen.queryByText('protected content')).not.toBeInTheDocument()
+  })
+
+  it('renders children when ready and authenticated', () => {
+    renderWithAuth({ isAuthReady: true, isAuthenticated: true })
+    expect(screen.getByText('protected content')).toBeInTheDocument()
+    expect(screen.queryByText(/you must be logged in/i)).not.toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/Components/RegisterForm.jsx
+++ b/src/frontend/src/Components/RegisterForm.jsx
@@ -1,10 +1,11 @@
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useState } from 'react'
 import { useAuth } from '../context/authContext'
 import './RegisterForm.css'
 
 const RegisterForm = () => {
   const { login } = useAuth()
+  const navigate = useNavigate()
   const [formData, setFormData] = useState({
     // capture only the fields needed for account creation. Email is no
     // longer collected in this simplified registration flow.
@@ -98,6 +99,7 @@ const RegisterForm = () => {
       if (loginResponse.ok) {
         const loginData = await loginResponse.json()
         login(loginData)
+        navigate('/profile')
       }
 
       setFormData({

--- a/src/frontend/src/Components/RegisterForm.jsx
+++ b/src/frontend/src/Components/RegisterForm.jsx
@@ -1,8 +1,10 @@
 import { Link } from 'react-router-dom'
 import { useState } from 'react'
+import { useAuth } from '../context/authContext'
 import './RegisterForm.css'
 
 const RegisterForm = () => {
+  const { login } = useAuth()
   const [formData, setFormData] = useState({
     // capture only the fields needed for account creation. Email is no
     // longer collected in this simplified registration flow.
@@ -82,6 +84,21 @@ const RegisterForm = () => {
         setSuccess(data.message)
       else
         setSuccess('Account created successfully!!')
+
+      const loginResponse = await fetch('/api/users/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          username: formData.username,
+          password: formData.password,
+        }),
+      })
+
+      if (loginResponse.ok) {
+        const loginData = await loginResponse.json()
+        login(loginData)
+      }
 
       setFormData({
         username: '',

--- a/src/frontend/src/Components/RegisterForm.test.jsx
+++ b/src/frontend/src/Components/RegisterForm.test.jsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { AuthContext } from '../context/authContext'
+import RegisterForm from './RegisterForm'
+
+function renderRegister(loginSpy = vi.fn()) {
+  return render(
+    <MemoryRouter initialEntries={['/register']}>
+      <AuthContext.Provider value={{ login: loginSpy, isAuthenticated: false, isAuthReady: true }}>
+        <Routes>
+          <Route path="/register" element={<RegisterForm />} />
+          <Route path="/profile" element={<div>profile page</div>} />
+        </Routes>
+      </AuthContext.Provider>
+    </MemoryRouter>
+  )
+}
+
+function fillForm({ username = 'newuser', password = 'pass123', confirm = 'pass123', terms = true, privacy = true } = {}) {
+  fireEvent.change(screen.getByLabelText(/^username/i), { target: { value: username } })
+  fireEvent.change(screen.getByLabelText(/^password$/i), { target: { value: password } })
+  fireEvent.change(screen.getByLabelText(/confirm password/i), { target: { value: confirm } })
+  if (terms) fireEvent.click(screen.getByLabelText(/terms of use/i))
+  if (privacy) fireEvent.click(screen.getByLabelText(/privacy policy/i))
+}
+
+describe('RegisterForm', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+    sessionStorage.clear()
+  })
+
+  it('renders username, password, confirmPassword fields and checkboxes', () => {
+    renderRegister()
+    expect(screen.getByLabelText(/^username/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/terms of use/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/privacy policy/i)).toBeInTheDocument()
+  })
+
+  it('shows error when passwords do not match', async () => {
+    renderRegister()
+    fillForm({ confirm: 'different' })
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/passwords do not match/i)
+    )
+  })
+
+  it('shows error when terms checkbox is not accepted', async () => {
+    renderRegister()
+    fillForm({ terms: false })
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/terms of service/i)
+    )
+  })
+
+  it('shows error when privacy checkbox is not accepted', async () => {
+    renderRegister()
+    fillForm({ privacy: false })
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'))
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/privacy policy/i)
+    )
+  })
+
+  it('submit button is disabled while submitting', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ username: 'newuser' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    renderRegister()
+    fillForm()
+    const btn = screen.getByRole('button', { name: /create account/i })
+    fireEvent.submit(btn.closest('form'))
+
+    expect(btn).toBeDisabled()
+    await waitFor(() => expect(btn).not.toBeDisabled())
+  })
+
+  it('sends correct payload to /api/users/auth/register', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ username: 'newuser' }), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    renderRegister()
+    fillForm()
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'))
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+    const [url, options] = fetchSpy.mock.calls[0]
+    expect(url).toBe('/api/users/auth/register')
+    expect(JSON.parse(options.body)).toEqual({ username: 'newuser', password: 'pass123' })
+  })
+
+  it('shows success message on 201', async () => {
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ username: 'newuser' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'a', refresh_token: 'r', token_type: 'bearer' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+
+    renderRegister()
+    fillForm()
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/account created/i)
+    )
+  })
+
+  it('calls login() and redirects to /profile after auto-login succeeds', async () => {
+    const loginSpy = vi.fn()
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ username: 'newuser' }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ access_token: 'a', refresh_token: 'r', token_type: 'bearer' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+
+    renderRegister(loginSpy)
+    fillForm()
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'))
+
+    await waitFor(() => expect(loginSpy).toHaveBeenCalledWith(
+      { access_token: 'a', refresh_token: 'r', token_type: 'bearer' }
+    ))
+    await waitFor(() => expect(screen.getByText('profile page')).toBeInTheDocument())
+  })
+
+  it('shows error on failed registration (e.g. 409 conflict)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Username already taken' }), {
+        status: 409,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    renderRegister()
+    fillForm()
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/username already taken/i)
+    )
+  })
+
+  it('shows error on non-JSON error body (e.g. 502)', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response('<html>Bad Gateway</html>', {
+        status: 502,
+        headers: { 'Content-Type': 'text/html' },
+      })
+    )
+
+    renderRegister()
+    fillForm()
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/failed to create account/i)
+    )
+  })
+
+  it('shows connection error when fetch throws', async () => {
+    vi.spyOn(global, 'fetch').mockRejectedValueOnce(new Error('Network error'))
+
+    renderRegister()
+    fillForm()
+    fireEvent.submit(screen.getByRole('button', { name: /create account/i }).closest('form'))
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/unable to connect/i)
+    )
+  })
+})

--- a/src/frontend/src/context/authContext.jsx
+++ b/src/frontend/src/context/authContext.jsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, useState } from 'react'
 import { getStoredAuth, saveAuth, clearAuth } from './authStorage'
 
-const AuthContext = createContext(null)
+export const AuthContext = createContext(null)
 
 export function AuthProvider({ children }) {
   const [auth, setAuth] = useState({

--- a/src/frontend/src/context/authContext.jsx
+++ b/src/frontend/src/context/authContext.jsx
@@ -9,6 +9,7 @@ export function AuthProvider({ children }) {
     refresh_token: null,
     token_type: null,
   })
+  const [isAuthReady, setIsAuthReady] = useState(false)
 
   useEffect(() => {
     const storedAuth = getStoredAuth()
@@ -20,6 +21,8 @@ export function AuthProvider({ children }) {
         token_type: storedAuth.token_type,
       })
     }
+
+    setIsAuthReady(true)
   }, [])
 
   const login = (authData, rememberMe = false) => {
@@ -49,12 +52,14 @@ export function AuthProvider({ children }) {
   const value = useMemo(() => ({
     auth,
     isAuthenticated,
+    isAuthReady,
     login,
     logout,
-  }), [auth, isAuthenticated])
+  }), [auth, isAuthenticated, isAuthReady])
 
   console.log('Auth state:', auth)
   console.log('isAuthenticated:', isAuthenticated)
+
   return (
     <AuthContext.Provider value={value}>
       {children}

--- a/src/frontend/src/context/authContext.test.jsx
+++ b/src/frontend/src/context/authContext.test.jsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { AuthProvider, useAuth } from './authContext'
+
+const MOCK_AUTH = {
+  access_token: 'acc',
+  refresh_token: 'ref',
+  token_type: 'bearer',
+}
+
+function wrapper({ children }) {
+  return <AuthProvider>{children}</AuthProvider>
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+})
+
+describe('AuthProvider — hydration', () => {
+  it('isAuthReady becomes true after mount', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    await act(async () => {})
+    expect(result.current.isAuthReady).toBe(true)
+  })
+
+  it('isAuthenticated is false when storage is empty on mount', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    await act(async () => {})
+    expect(result.current.isAuthenticated).toBe(false)
+  })
+
+  it('isAuthenticated is true when sessionStorage has valid tokens on mount', async () => {
+    sessionStorage.setItem('access_token', 'acc')
+    sessionStorage.setItem('refresh_token', 'ref')
+    sessionStorage.setItem('token_type', 'bearer')
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    await act(async () => {})
+    expect(result.current.isAuthenticated).toBe(true)
+  })
+
+  it('isAuthenticated is true when localStorage has valid tokens on mount', async () => {
+    localStorage.setItem('access_token', 'acc')
+    localStorage.setItem('refresh_token', 'ref')
+    localStorage.setItem('token_type', 'bearer')
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    await act(async () => {})
+    expect(result.current.isAuthenticated).toBe(true)
+  })
+})
+
+describe('AuthProvider — login', () => {
+  it('login() sets isAuthenticated to true and saves to sessionStorage by default', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    await act(async () => { result.current.login(MOCK_AUTH) })
+    expect(result.current.isAuthenticated).toBe(true)
+    expect(sessionStorage.getItem('access_token')).toBe('acc')
+    expect(localStorage.getItem('access_token')).toBeNull()
+  })
+
+  it('login(data, true) saves to localStorage and clears sessionStorage', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    await act(async () => { result.current.login(MOCK_AUTH, true) })
+    expect(result.current.isAuthenticated).toBe(true)
+    expect(localStorage.getItem('access_token')).toBe('acc')
+    expect(sessionStorage.getItem('access_token')).toBeNull()
+  })
+})
+
+describe('AuthProvider — logout', () => {
+  it('logout() sets isAuthenticated to false and clears both storages', async () => {
+    sessionStorage.setItem('access_token', 'acc')
+    sessionStorage.setItem('refresh_token', 'ref')
+    sessionStorage.setItem('token_type', 'bearer')
+    const { result } = renderHook(() => useAuth(), { wrapper })
+    await act(async () => {})
+    expect(result.current.isAuthenticated).toBe(true)
+    await act(async () => { result.current.logout() })
+    expect(result.current.isAuthenticated).toBe(false)
+    expect(sessionStorage.getItem('access_token')).toBeNull()
+    expect(localStorage.getItem('access_token')).toBeNull()
+  })
+})
+
+describe('useAuth', () => {
+  it('throws when used outside AuthProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => renderHook(() => useAuth())).toThrow('useAuth must be used within an AuthProvider')
+    spy.mockRestore()
+  })
+})

--- a/src/frontend/src/context/authStorage.test.js
+++ b/src/frontend/src/context/authStorage.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getStoredAuth, saveAuth, clearAuth } from './authStorage'
+
+const MOCK_AUTH = {
+  access_token: 'acc',
+  refresh_token: 'ref',
+  token_type: 'bearer',
+}
+
+function seedSession() {
+  sessionStorage.setItem('access_token', 'acc')
+  sessionStorage.setItem('refresh_token', 'ref')
+  sessionStorage.setItem('token_type', 'bearer')
+}
+
+function seedLocal() {
+  localStorage.setItem('access_token', 'acc')
+  localStorage.setItem('refresh_token', 'ref')
+  localStorage.setItem('token_type', 'bearer')
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+})
+
+describe('getStoredAuth', () => {
+  it('returns null when both storages are empty', () => {
+    expect(getStoredAuth()).toBeNull()
+  })
+
+  it('returns session tokens when sessionStorage has all three keys', () => {
+    seedSession()
+    expect(getStoredAuth()).toMatchObject(MOCK_AUTH)
+  })
+
+  it('falls back to localStorage when sessionStorage is empty', () => {
+    seedLocal()
+    expect(getStoredAuth()).toMatchObject(MOCK_AUTH)
+  })
+
+  it('prefers sessionStorage over localStorage when both have tokens', () => {
+    sessionStorage.setItem('access_token', 'session-acc')
+    sessionStorage.setItem('refresh_token', 'session-ref')
+    sessionStorage.setItem('token_type', 'bearer')
+    localStorage.setItem('access_token', 'local-acc')
+    localStorage.setItem('refresh_token', 'local-ref')
+    localStorage.setItem('token_type', 'bearer')
+    expect(getStoredAuth()?.access_token).toBe('session-acc')
+  })
+})
+
+describe('saveAuth', () => {
+  it('writes to sessionStorage and clears localStorage when rememberMe is false', () => {
+    seedLocal()
+    saveAuth(MOCK_AUTH, false)
+    expect(sessionStorage.getItem('access_token')).toBe('acc')
+    expect(sessionStorage.getItem('refresh_token')).toBe('ref')
+    expect(sessionStorage.getItem('token_type')).toBe('bearer')
+    expect(localStorage.getItem('access_token')).toBeNull()
+    expect(localStorage.getItem('refresh_token')).toBeNull()
+    expect(localStorage.getItem('token_type')).toBeNull()
+  })
+
+  it('writes to localStorage and clears sessionStorage when rememberMe is true', () => {
+    seedSession()
+    saveAuth(MOCK_AUTH, true)
+    expect(localStorage.getItem('access_token')).toBe('acc')
+    expect(localStorage.getItem('refresh_token')).toBe('ref')
+    expect(localStorage.getItem('token_type')).toBe('bearer')
+    expect(sessionStorage.getItem('access_token')).toBeNull()
+    expect(sessionStorage.getItem('refresh_token')).toBeNull()
+    expect(sessionStorage.getItem('token_type')).toBeNull()
+  })
+})
+
+describe('clearAuth', () => {
+  it('removes all three keys from both storages', () => {
+    seedSession()
+    seedLocal()
+    clearAuth()
+    expect(sessionStorage.getItem('access_token')).toBeNull()
+    expect(sessionStorage.getItem('refresh_token')).toBeNull()
+    expect(sessionStorage.getItem('token_type')).toBeNull()
+    expect(localStorage.getItem('access_token')).toBeNull()
+    expect(localStorage.getItem('refresh_token')).toBeNull()
+    expect(localStorage.getItem('token_type')).toBeNull()
+  })
+})

--- a/src/frontend/src/pages/Login.jsx
+++ b/src/frontend/src/pages/Login.jsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import './Login.css'
 import NavbarComponent from '../Components/Navbar'
 import { useState } from 'react'
@@ -9,6 +9,7 @@ export default function Login() {
   const [success, setSuccess] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { login } = useAuth()
+  const navigate = useNavigate()
 
   const [formData, setFormData] = useState({
     username: '',
@@ -74,14 +75,7 @@ export default function Login() {
       }
 
       login(data, formData.rememberMe)
-
-      setFormData((prev) => ({
-        ...prev,
-        username: '',
-        password: '',
-      }))
-
-      setSuccess('Login successful.')
+      navigate('/profile')
     } catch (err) {
       console.error(err)
       setError('Unable to connect to the server.')

--- a/src/frontend/src/pages/Login.test.jsx
+++ b/src/frontend/src/pages/Login.test.jsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { AuthProvider } from '../context/authContext'
 import Login from './Login'
 
@@ -9,6 +9,19 @@ function renderLogin() {
     <AuthProvider>
       <MemoryRouter>
         <Login />
+      </MemoryRouter>
+    </AuthProvider>
+  )
+}
+
+function renderLoginWithRoutes() {
+  return render(
+    <AuthProvider>
+      <MemoryRouter initialEntries={['/login']}>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/profile" element={<div>profile page</div>} />
+        </Routes>
       </MemoryRouter>
     </AuthProvider>
   )
@@ -79,8 +92,7 @@ describe('Login page', () => {
     fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'p' } })
     fireEvent.submit(screen.getByRole('button', { name: /sign in/i }).closest('form'))
 
-    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/login successful/i))
-    expect(sessionStorage.getItem('access_token')).toBe('acc')
+    await waitFor(() => expect(sessionStorage.getItem('access_token')).toBe('acc'))
     expect(sessionStorage.getItem('refresh_token')).toBe('ref')
   })
 
@@ -128,5 +140,40 @@ describe('Login page', () => {
     await waitFor(() =>
       expect(screen.getByRole('alert')).toHaveTextContent(/unable to connect/i)
     )
+  })
+
+  it('redirects to /profile on successful login', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ access_token: 'a', refresh_token: 'r', token_type: 'bearer' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+
+    renderLoginWithRoutes()
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'u' } })
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'p' } })
+    fireEvent.submit(screen.getByRole('button', { name: /sign in/i }).closest('form'))
+
+    await waitFor(() => expect(screen.getByText('profile page')).toBeInTheDocument())
+  })
+
+  it('stores tokens in localStorage when rememberMe is checked', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ access_token: 'acc', refresh_token: 'ref', token_type: 'bearer' }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+
+    renderLogin()
+    fireEvent.change(screen.getByLabelText(/username/i), { target: { value: 'u' } })
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'p' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: /remember me/i }))
+    fireEvent.submit(screen.getByRole('button', { name: /sign in/i }).closest('form'))
+
+    await waitFor(() => expect(localStorage.getItem('access_token')).toBe('acc'))
+    expect(localStorage.getItem('refresh_token')).toBe('ref')
+    expect(sessionStorage.getItem('access_token')).toBeNull()
   })
 })


### PR DESCRIPTION
This PR adds frontend protection for the Profile page using the existing AuthContext.

What was done:
- created route protection for `/profile`
- connected access control to `AuthContext`
- kept authenticated users able to access the page normally
- added an access-required state for unauthenticated users
- displayed a message explaining that login is required
- added a link/button to navigate to the login page

Behavior:
- authenticated users can access `/profile` normally
- unauthenticated users who try to access `/profile` will not see the profile content
- instead of exposing the page directly, the app shows a clear prompt indicating that login is required

Notes:
- this keeps the route protection reusable for future private pages
- no backend authorization changes were made
- no token refresh logic was added in this PR
- navbar dynamic behavior remains out of scope