### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/frontend/src/pages/Profile.jsx
+++ b/src/frontend/src/pages/Profile.jsx
@@ -5,6 +5,32 @@ import { getAvatarFilter } from '../utils/avatarFilter'
 import './Profile.css'
 import FriendsSidebar from '../Components/FriendsSidebar'
 
+function sanitizeAvatarUrl(rawUrl) {
+  const placeholder = '/avatar_placeholder.jpg'
+
+  if (typeof rawUrl !== 'string' || rawUrl.trim() === '') {
+    return placeholder
+  }
+
+  const url = rawUrl.trim()
+
+  // Allow relative URLs (served from this origin)
+  if (url.startsWith('/')) {
+    return url
+  }
+
+  try {
+    const parsed = new URL(url, window.location.origin)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return parsed.toString()
+    }
+  } catch {
+    // Fall through to placeholder on parse errors
+  }
+
+  return placeholder
+}
+
 export default function Profile() {
   const _rawId = parseInt(localStorage.getItem('user_id'), 10)
   const USER_ID = Number.isNaN(_rawId) ? 1 : _rawId
@@ -37,7 +63,7 @@ export default function Profile() {
         setProfile({
           displayName: profileData.display_name ?? '',
           darkMode:    profileData.dark_mode ?? false,
-          avatarUrl:   profileData.avatar_url ?? '/avatar_placeholder.jpg',
+          avatarUrl:   sanitizeAvatarUrl(profileData.avatar_url),
           username:    profileData.username,
           bio:         profileData.bio ?? '',
           status:      profileData.status,
@@ -59,7 +85,12 @@ export default function Profile() {
     const { name, value, type, checked } = e.target
     setProfile(prev => ({
       ...prev,
-      [name]: type === 'checkbox' ? checked : value,
+      [name]:
+        type === 'checkbox'
+          ? checked
+          : name === 'avatarUrl'
+            ? sanitizeAvatarUrl(value)
+            : value,
     }))
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/biralavor/42_transcendence/security/code-scanning/2](https://github.com/biralavor/42_transcendence/security/code-scanning/2)

In general, the fix is to ensure that any value taken from the DOM and later used in a potentially dangerous context (here, a URL in JSX) is validated and/or normalized so that only expected, safe values are allowed. Instead of trusting whatever ends up in `profile.avatarUrl`, we should enforce basic URL constraints (e.g., allow only `http:`, `https:`, or relative URLs), and fall back to a safe placeholder if the value is not acceptable.

The least invasive fix that preserves existing behavior is:

1. Introduce a small, local helper function `sanitizeAvatarUrl` inside `Profile.jsx` that:
   - Accepts a candidate URL.
   - Returns the placeholder (`'/avatar_placeholder.jpg'`) if the value is empty/non‑string.
   - Checks that the URL is either relative (starts with `/`) or uses an allowed scheme (`http:` or `https:`).
   - If the value fails validation or parsing, returns the placeholder.
2. Use this helper at:
   - The point where we initialize `profile` from `profileData` (line 40): wrap `profileData.avatar_url` with `sanitizeAvatarUrl(...)` instead of using it directly.
   - The `handleChange` updater (line 62): when the changed field is `avatarUrl`, store `sanitizeAvatarUrl(value)` instead of `value`. This directly addresses the taint path from `e.target.name`/`value` into `profile.avatarUrl`.
3. Keep the `<img src={profile.avatarUrl}>` unchanged, since now that state property is always sanitized.

All changes are confined to `src/frontend/src/pages/Profile.jsx`. No new external libraries are needed; we can use the built‑in `URL` constructor for robust parsing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
