### PR TITLE
feat: #168 added create, join and get tournament endpoints

### DIFF
--- a/src/backend/game-service/alembic/env.py
+++ b/src/backend/game-service/alembic/env.py
@@ -18,10 +18,10 @@ from shared.config.settings import settings  # noqa: E402
 from shared.database import Base             # noqa: E402
 
 # Import the service models so Alembic can detect them in Base.metadata
-from service.models.match import Match  # noqa: E402, F401
+from service.models import Match, Tournament, TournamentParticipant  # noqa: E402, F401
 
 # Tables owned by this service — Alembic will ONLY manage these.
-_SERVICE_TABLES = {"matches"}
+_SERVICE_TABLES = {"matches", "tournaments", "tournament_participants"}
 
 # Each service gets its own version-tracking table so they don't collide.
 _VERSION_TABLE = "alembic_version_game"

--- a/src/backend/game-service/alembic/versions/20260401_b3c7f2a9d1e8_add_tournaments_table.py
+++ b/src/backend/game-service/alembic/versions/20260401_b3c7f2a9d1e8_add_tournaments_table.py
@@ -25,7 +25,7 @@ def upgrade() -> None:
         sa.Column('name', sa.String(length=100), nullable=False),
         sa.Column('creator_id', sa.Integer(), nullable=False),
         sa.Column('max_participants', sa.Integer(), nullable=False),
-        sa.Column('status', sa.String(length=20), nullable=False, server_default='waiting'),
+        sa.Column('status', sa.String(length=20), nullable=False, server_default=sa.text("'open'")),
         sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text('now()')),
         sa.PrimaryKeyConstraint('id'),
     )

--- a/src/backend/game-service/alembic/versions/20260401_b3c7f2a9d1e8_add_tournaments_table.py
+++ b/src/backend/game-service/alembic/versions/20260401_b3c7f2a9d1e8_add_tournaments_table.py
@@ -1,0 +1,35 @@
+"""add tournaments table
+
+Revision ID: b3c7f2a9d1e8
+Revises: e53b819dcceb
+Create Date: 2026-04-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'b3c7f2a9d1e8'
+down_revision: Union[str, None] = 'e53b819dcceb'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'tournaments',
+        sa.Column('id', sa.Integer(), nullable=False),
+        # Cross-service reference stored as plain integer — no ORM-level FK
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('creator_id', sa.Integer(), nullable=False),
+        sa.Column('max_participants', sa.Integer(), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False, server_default='waiting'),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.PrimaryKeyConstraint('id'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('tournaments')

--- a/src/backend/game-service/alembic/versions/20260401_c4d8e3b2f9a1_add_tournament_participants_table.py
+++ b/src/backend/game-service/alembic/versions/20260401_c4d8e3b2f9a1_add_tournament_participants_table.py
@@ -1,0 +1,32 @@
+"""add tournament_participants table
+
+Revision ID: c4d8e3b2f9a1
+Revises: b3c7f2a9d1e8
+Create Date: 2026-04-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4d8e3b2f9a1'
+down_revision: Union[str, None] = 'b3c7f2a9d1e8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'tournament_participants',
+        sa.Column('tournament_id', sa.Integer(), sa.ForeignKey('tournaments.id'), nullable=False),
+        # Cross-service reference stored as plain integer — no ORM-level FK
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('joined_at', sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.PrimaryKeyConstraint('tournament_id', 'user_id'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('tournament_participants')

--- a/src/backend/game-service/auth.py
+++ b/src/backend/game-service/auth.py
@@ -1,0 +1,45 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from jose import ExpiredSignatureError, JWTError, jwt
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from shared.config.settings import settings
+from shared.database import get_db
+
+_bearer = HTTPBearer()
+_ALGORITHM = "HS256"
+
+
+async def get_current_user_id(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+    db: AsyncSession = Depends(get_db),
+) -> int:
+    try:
+        payload = jwt.decode(
+            credentials.credentials, settings.JWT_SECRET_KEY, algorithms=[_ALGORITHM]
+        )
+        credential_id: int | None = payload.get("credential_id")
+        if credential_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+            )
+    except ExpiredSignatureError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Token expired"
+        ) from exc
+    except JWTError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
+        ) from exc
+
+    result = await db.execute(
+        text("SELECT id FROM users WHERE credential_id = :cid"),
+        {"cid": credential_id},
+    )
+    row = result.first()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
+        )
+    return row[0]

--- a/src/backend/game-service/auth.py
+++ b/src/backend/game-service/auth.py
@@ -1,3 +1,6 @@
+import os
+
+import httpx
 from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import ExpiredSignatureError, JWTError, jwt
@@ -9,6 +12,17 @@ from shared.database import get_db
 
 _bearer = HTTPBearer()
 _ALGORITHM = "HS256"
+_USER_SERVICE_PORT = os.getenv("USER_SERVICE_PORT", "8001")
+_USER_SERVICE_URL = f"http://user-service:{_USER_SERVICE_PORT}"
+
+
+async def _lookup_user_id(db: AsyncSession, credential_id: int) -> int | None:
+    result = await db.execute(
+        text("SELECT id FROM users WHERE credential_id = :cid"),
+        {"cid": credential_id},
+    )
+    row = result.first()
+    return row[0] if row else None
 
 
 async def get_current_user_id(
@@ -33,13 +47,30 @@ async def get_current_user_id(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token"
         ) from exc
 
-    result = await db.execute(
-        text("SELECT id FROM users WHERE credential_id = :cid"),
-        {"cid": credential_id},
-    )
-    row = result.first()
-    if row is None:
+    # Fast path: user already exists in the DB
+    user_id = await _lookup_user_id(db, credential_id)
+    if user_id is not None:
+        return user_id
+
+    # Fallback: call user-service /auth/me to auto-create the user row
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(
+            f"{_USER_SERVICE_URL}/auth/me",
+            headers={"Authorization": f"Bearer {credentials.credentials}"},
+        )
+    if resp.status_code == 401:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail=resp.json().get("detail", "Invalid token")
+        )
+    if resp.status_code != 200:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY, detail="User service unavailable"
+        )
+
+    # Re-query after user-service created the row
+    user_id = await _lookup_user_id(db, credential_id)
+    if user_id is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
-    return row[0]
+    return user_id

--- a/src/backend/game-service/models/__init__.py
+++ b/src/backend/game-service/models/__init__.py
@@ -1,3 +1,5 @@
 from .match import Match
+from .tournament import Tournament
+from .tournament_participant import TournamentParticipant
 
-__all__ = ["Match"]
+__all__ = ["Match", "Tournament", "TournamentParticipant"]

--- a/src/backend/game-service/models/tournament.py
+++ b/src/backend/game-service/models/tournament.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String, TIMESTAMP
+from sqlalchemy.sql import func
+
+from shared.database import Base
+
+
+class Tournament(Base):
+    __tablename__ = "tournaments"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100), nullable=False)
+    # Cross-service reference stored as plain integer (no ORM-level FK)
+    creator_id = Column(Integer, nullable=False)
+    max_participants = Column(Integer, nullable=False)
+    status = Column(String(20), nullable=False, server_default='waiting')
+    created_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())

--- a/src/backend/game-service/models/tournament.py
+++ b/src/backend/game-service/models/tournament.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, TIMESTAMP
+from sqlalchemy import Column, Integer, String, TIMESTAMP, text
 from sqlalchemy.sql import func
 
 from shared.database import Base
@@ -12,5 +12,5 @@ class Tournament(Base):
     # Cross-service reference stored as plain integer (no ORM-level FK)
     creator_id = Column(Integer, nullable=False)
     max_participants = Column(Integer, nullable=False)
-    status = Column(String(20), nullable=False, server_default='waiting')
+    status = Column(String(20), nullable=False, server_default=text("'open'"))
     created_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())

--- a/src/backend/game-service/models/tournament_participant.py
+++ b/src/backend/game-service/models/tournament_participant.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, TIMESTAMP, ForeignKey
+from sqlalchemy.sql import func
+
+from shared.database import Base
+
+
+class TournamentParticipant(Base):
+    __tablename__ = "tournament_participants"
+
+    tournament_id = Column(Integer, ForeignKey("tournaments.id"), primary_key=True)
+    # Cross-service reference stored as plain integer (no ORM-level FK)
+    user_id = Column(Integer, primary_key=True)
+    joined_at = Column(TIMESTAMP(timezone=True), nullable=False, server_default=func.now())

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -1,11 +1,28 @@
 from datetime import datetime, timezone
 
 from sqlalchemy import or_, select, case, func, union_all
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from service.models.match import Match
 from service.models.tournament import Tournament
 from service.models.tournament_participant import TournamentParticipant
+
+
+class TournamentNotFound(Exception):
+    pass
+
+
+class TournamentNotOpen(Exception):
+    pass
+
+
+class UserAlreadyRegistered(Exception):
+    pass
+
+
+class TournamentFull(Exception):
+    pass
 
 
 async def create_match(db: AsyncSession, player1_id: int, player2_id: int) -> Match:
@@ -53,9 +70,32 @@ async def get_tournament_with_participants(
 async def join_tournament(
     db: AsyncSession, tournament_id: int, user_id: int
 ) -> TournamentParticipant:
+    # Lock the tournament row so concurrent requests cannot both pass the
+    # capacity check before either one commits.
+    result = await db.execute(
+        select(Tournament).where(Tournament.id == tournament_id).with_for_update()
+    )
+    tournament = result.scalars().first()
+    if tournament is None:
+        raise TournamentNotFound()
+    if tournament.status != "open":
+        raise TournamentNotOpen()
+
+    count_result = await db.execute(
+        select(func.count())
+        .select_from(TournamentParticipant)
+        .where(TournamentParticipant.tournament_id == tournament_id)
+    )
+    if count_result.scalar() >= tournament.max_participants:
+        raise TournamentFull()
+
     participant = TournamentParticipant(tournament_id=tournament_id, user_id=user_id)
     db.add(participant)
-    await db.commit()
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise UserAlreadyRegistered()
     await db.refresh(participant)
     return participant
 

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -4,6 +4,8 @@ from sqlalchemy import or_, select, case, func, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from service.models.match import Match
+from service.models.tournament import Tournament
+from service.models.tournament_participant import TournamentParticipant
 
 
 async def create_match(db: AsyncSession, player1_id: int, player2_id: int) -> Match:
@@ -17,6 +19,45 @@ async def create_match(db: AsyncSession, player1_id: int, player2_id: int) -> Ma
     await db.commit()
     await db.refresh(match)
     return match
+
+
+async def create_tournament(
+    db: AsyncSession, name: str, creator_id: int, max_participants: int
+) -> Tournament:
+    tournament = Tournament(
+        name=name,
+        creator_id=creator_id,
+        max_participants=max_participants,
+        status="open",
+    )
+    db.add(tournament)
+    await db.commit()
+    await db.refresh(tournament)
+    return tournament
+
+
+async def get_tournament_with_participants(
+    db: AsyncSession, tournament_id: int
+) -> tuple[Tournament, list[TournamentParticipant]] | None:
+    result = await db.execute(select(Tournament).where(Tournament.id == tournament_id))
+    tournament = result.scalars().first()
+    if tournament is None:
+        return None
+    participants_result = await db.execute(
+        select(TournamentParticipant).where(TournamentParticipant.tournament_id == tournament_id)
+    )
+    participants = list(participants_result.scalars().all())
+    return tournament, participants
+
+
+async def join_tournament(
+    db: AsyncSession, tournament_id: int, user_id: int
+) -> TournamentParticipant:
+    participant = TournamentParticipant(tournament_id=tournament_id, user_id=user_id)
+    db.add(participant)
+    await db.commit()
+    await db.refresh(participant)
+    return participant
 
 
 async def finish_match(

--- a/src/backend/game-service/requirements.txt
+++ b/src/backend/game-service/requirements.txt
@@ -1,4 +1,5 @@
 # Base deps come from backend-base image.
 # Add only game-service-specific RUNTIME packages here.
 # Test-only deps (pytest, httpx) live in requirements-test.txt.
+httpx==0.28.1
 python-jose[cryptography]==3.5.0

--- a/src/backend/game-service/requirements.txt
+++ b/src/backend/game-service/requirements.txt
@@ -1,3 +1,4 @@
 # Base deps come from backend-base image.
 # Add only game-service-specific RUNTIME packages here.
 # Test-only deps (pytest, httpx) live in requirements-test.txt.
+python-jose[cryptography]==3.5.0

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from service.history import get_match_history
-from service.persistence import create_match, finish_match, get_leaderboard, get_match, get_user_matches, get_user_stats
+from service.persistence import create_match, create_tournament, finish_match, get_leaderboard, get_match, get_tournament_with_participants, get_user_matches, get_user_stats, join_tournament
 from service.schemas import (
     LeaderboardEntryResponse,
     MatchCreateRequest,
@@ -12,6 +12,11 @@ from service.schemas import (
     MatchHistoryItem,
     MatchResponse,
     StatsResponse,
+    JoinTournamentRequest,
+    TournamentCreateRequest,
+    TournamentCreateResponse,
+    TournamentDetailResponse,
+    TournamentParticipantResponse,
 )
 from shared.database import get_db
 
@@ -49,6 +54,48 @@ async def user_matches(user_id: int, session: SessionDependency):
 @router.post("/matches", status_code=status.HTTP_201_CREATED, response_model=MatchResponse)
 async def start_match(body: MatchCreateRequest, session: SessionDependency):
     return await create_match(session, body.player1_id, body.player2_id)
+
+
+@router.post("/tournaments", status_code=status.HTTP_201_CREATED, response_model=TournamentCreateResponse)
+async def create_tournament_endpoint(body: TournamentCreateRequest, session: SessionDependency):
+    tournament = await create_tournament(session, body.name, body.creator_id, body.max_participants)
+    return TournamentCreateResponse(
+        id=tournament.id,
+        join_link=f"/api/tournaments/{tournament.id}/join",
+    )
+
+
+@router.get("/tournaments/{tournament_id}", response_model=TournamentDetailResponse)
+async def get_tournament(tournament_id: int, session: SessionDependency):
+    result = await get_tournament_with_participants(session, tournament_id)
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+    tournament, participants = result
+    return TournamentDetailResponse(
+        id=tournament.id,
+        name=tournament.name,
+        creator_id=tournament.creator_id,
+        max_participants=tournament.max_participants,
+        status=tournament.status,
+        created_at=tournament.created_at,
+        participants=[TournamentParticipantResponse(user_id=p.user_id, joined_at=p.joined_at) for p in participants],
+    )
+
+
+@router.post("/tournaments/{tournament_id}/join", status_code=status.HTTP_201_CREATED)
+async def join_tournament_endpoint(tournament_id: int, body: JoinTournamentRequest, session: SessionDependency):
+    result = await get_tournament_with_participants(session, tournament_id)
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+    tournament, participants = result
+    if tournament.status != "open":
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Tournament already started")
+    if any(p.user_id == body.user_id for p in participants):
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User already registered")
+    if len(participants) >= tournament.max_participants:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Tournament is full")
+    await join_tournament(session, tournament_id, body.user_id)
+    return {"detail": "Joined successfully"}
 
 
 @router.post("/matches/{match_id}/finish", response_model=MatchResponse)

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -3,6 +3,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from service.auth import get_current_user_id
 from service.history import get_match_history
 from service.persistence import (
     TournamentFull,
@@ -26,7 +27,6 @@ from service.schemas import (
     MatchHistoryItem,
     MatchResponse,
     StatsResponse,
-    JoinTournamentRequest,
     TournamentCreateRequest,
     TournamentCreateResponse,
     TournamentDetailResponse,
@@ -71,8 +71,12 @@ async def start_match(body: MatchCreateRequest, session: SessionDependency):
 
 
 @router.post("/tournaments", status_code=status.HTTP_201_CREATED, response_model=TournamentCreateResponse)
-async def create_tournament_endpoint(body: TournamentCreateRequest, session: SessionDependency):
-    tournament = await create_tournament(session, body.name, body.creator_id, body.max_participants)
+async def create_tournament_endpoint(
+    body: TournamentCreateRequest,
+    session: SessionDependency,
+    creator_id: int = Depends(get_current_user_id),
+):
+    tournament = await create_tournament(session, body.name, creator_id, body.max_participants)
     return TournamentCreateResponse(
         id=tournament.id,
         join_link=f"/api/game/tournaments/{tournament.id}/join",
@@ -97,9 +101,13 @@ async def get_tournament(tournament_id: int, session: SessionDependency):
 
 
 @router.post("/tournaments/{tournament_id}/join", status_code=status.HTTP_201_CREATED)
-async def join_tournament_endpoint(tournament_id: int, body: JoinTournamentRequest, session: SessionDependency):
+async def join_tournament_endpoint(
+    tournament_id: int,
+    session: SessionDependency,
+    user_id: int = Depends(get_current_user_id),
+):
     try:
-        await join_tournament(session, tournament_id, body.user_id)
+        await join_tournament(session, tournament_id, user_id)
     except TournamentNotFound:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
     except TournamentNotOpen:

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -1,11 +1,24 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from service.history import get_match_history
-from service.persistence import create_match, create_tournament, finish_match, get_leaderboard, get_match, get_tournament_with_participants, get_user_matches, get_user_stats, join_tournament
+from service.persistence import (
+    TournamentFull,
+    TournamentNotFound,
+    TournamentNotOpen,
+    UserAlreadyRegistered,
+    create_match,
+    create_tournament,
+    finish_match,
+    get_leaderboard,
+    get_match,
+    get_tournament_with_participants,
+    get_user_matches,
+    get_user_stats,
+    join_tournament,
+)
 from service.schemas import (
     LeaderboardEntryResponse,
     MatchCreateRequest,
@@ -85,20 +98,16 @@ async def get_tournament(tournament_id: int, session: SessionDependency):
 
 @router.post("/tournaments/{tournament_id}/join", status_code=status.HTTP_201_CREATED)
 async def join_tournament_endpoint(tournament_id: int, body: JoinTournamentRequest, session: SessionDependency):
-    result = await get_tournament_with_participants(session, tournament_id)
-    if result is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
-    tournament, participants = result
-    if tournament.status != "open":
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Tournament already started")
-    if any(p.user_id == body.user_id for p in participants):
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User already registered")
-    if len(participants) >= tournament.max_participants:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Tournament is full")
     try:
         await join_tournament(session, tournament_id, body.user_id)
-    except IntegrityError:
+    except TournamentNotFound:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+    except TournamentNotOpen:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Tournament already started")
+    except UserAlreadyRegistered:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User already registered")
+    except TournamentFull:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Tournament is full")
     return {"detail": "Joined successfully"}
 
 

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -1,6 +1,7 @@
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from service.history import get_match_history
@@ -61,7 +62,7 @@ async def create_tournament_endpoint(body: TournamentCreateRequest, session: Ses
     tournament = await create_tournament(session, body.name, body.creator_id, body.max_participants)
     return TournamentCreateResponse(
         id=tournament.id,
-        join_link=f"/api/tournaments/{tournament.id}/join",
+        join_link=f"/api/game/tournaments/{tournament.id}/join",
     )
 
 
@@ -94,7 +95,10 @@ async def join_tournament_endpoint(tournament_id: int, body: JoinTournamentReque
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User already registered")
     if len(participants) >= tournament.max_participants:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Tournament is full")
-    await join_tournament(session, tournament_id, body.user_id)
+    try:
+        await join_tournament(session, tournament_id, body.user_id)
+    except IntegrityError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User already registered")
     return {"detail": "Joined successfully"}
 
 

--- a/src/backend/game-service/schemas.py
+++ b/src/backend/game-service/schemas.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
@@ -55,3 +56,37 @@ class MatchHistoryItem(BaseModel):
     result: str   # "Win" | "Loss"
     score: str    # e.g. "11-3" (user score first, ASCII hyphen)
     date: str     # finished_at ISO string, "" if null
+
+
+class TournamentCreateRequest(BaseModel):
+    name: str
+    creator_id: int
+    max_participants: Literal[4, 8]
+
+
+class JoinTournamentRequest(BaseModel):
+    user_id: int
+
+
+class TournamentCreateResponse(BaseModel):
+    id: int
+    join_link: str
+
+
+class TournamentParticipantResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    user_id: int
+    joined_at: datetime
+
+
+class TournamentDetailResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    creator_id: int
+    max_participants: int
+    status: str
+    created_at: datetime
+    participants: list[TournamentParticipantResponse]

--- a/src/backend/game-service/schemas.py
+++ b/src/backend/game-service/schemas.py
@@ -60,12 +60,7 @@ class MatchHistoryItem(BaseModel):
 
 class TournamentCreateRequest(BaseModel):
     name: str
-    creator_id: int
     max_participants: Literal[4, 8]
-
-
-class JoinTournamentRequest(BaseModel):
-    user_id: int
 
 
 class TournamentCreateResponse(BaseModel):

--- a/src/backend/request.http
+++ b/src/backend/request.http
@@ -85,3 +85,26 @@ GET https://localhost:8443/api/game/stats/1 HTTP/1.1
 
 ### Get match history for a user
 GET https://localhost:8443/api/game/matches/1 HTTP/1.1
+
+### ── TOURNAMENTS ────────────────────────────────────────────────────────────
+
+### Create tournament
+POST https://localhost:8443/api/game/tournaments HTTP/1.1
+content-type: application/json
+
+{
+    "name": "Spring Tournament",
+    "creator_id": 1,
+    "max_participants": 4
+}
+
+### Get tournament details (replace 1 with tournament id)
+GET https://localhost:8443/api/game/tournaments/1 HTTP/1.1
+
+### Join tournament (replace 1 with tournament id)
+POST https://localhost:8443/api/game/tournaments/1/join HTTP/1.1
+content-type: application/json
+
+{
+    "user_id": 2
+}

--- a/src/backend/request.http
+++ b/src/backend/request.http
@@ -19,6 +19,15 @@ content-type: application/json
     "password": "maurodri123"
 }
 
+###
+POST https://localhost:8443/api/users/auth/login HTTP/1.1
+content-type: application/json
+
+{
+    "username": "bira",
+    "password": "bira123"
+}
+
 ### Refresh (replace <refresh_token> with the refresh_token from login response)
 POST https://localhost:8443/api/users/auth/refresh HTTP/1.1
 content-type: application/json
@@ -88,23 +97,19 @@ GET https://localhost:8443/api/game/matches/1 HTTP/1.1
 
 ### ── TOURNAMENTS ────────────────────────────────────────────────────────────
 
-### Create tournament
+### Create tournament (replace <access_token> with the access_token from login response)
 POST https://localhost:8443/api/game/tournaments HTTP/1.1
 content-type: application/json
+Authorization: Bearer <access_token>
 
 {
     "name": "Spring Tournament",
-    "creator_id": 1,
     "max_participants": 4
 }
 
 ### Get tournament details (replace 1 with tournament id)
 GET https://localhost:8443/api/game/tournaments/1 HTTP/1.1
 
-### Join tournament (replace 1 with tournament id)
+### Join tournament (replace 1 with tournament id, replace <access_token>)
 POST https://localhost:8443/api/game/tournaments/1/join HTTP/1.1
-content-type: application/json
-
-{
-    "user_id": 2
-}
+Authorization: Bearer <access_token>

--- a/src/backend/user-service/service.py
+++ b/src/backend/user-service/service.py
@@ -43,7 +43,8 @@ async def authenticate(login: Login, session: AsyncSession) -> LoginResponse:
         )
     access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(
-        data={"sub": credential.username}, expires_delta=access_token_expires
+        data={"sub": credential.username, "credential_id": credential.id},
+        expires_delta=access_token_expires,
     )
     raw_refresh_token = secrets.token_hex(32)
     refresh_token_hash = hashlib.sha256(raw_refresh_token.encode()).hexdigest()
@@ -77,7 +78,7 @@ async def refresh_access_token(body: RefreshRequest, session: AsyncSession) -> L
     if credential is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid refresh token")
     access_token = create_access_token(
-        data={"sub": credential.username},
+        data={"sub": credential.username, "credential_id": credential.id},
         expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
     )
     raw_refresh_token = secrets.token_hex(32)


### PR DESCRIPTION
Claude suggests we use the JWT key to get the current user id, but we only send the credential username in the payload.
Until we decide how to proceed, the create tournament endpoint requires a user_id in the request body.

Closes #168 
