### PR TITLE
feat: #185 tournament result endpoint

### DIFF
--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -35,6 +35,18 @@ class TournamentNotEnoughParticipants(Exception):
     pass
 
 
+class TournamentMatchNotFound(Exception):
+    pass
+
+
+class TournamentMatchAlreadyFinished(Exception):
+    pass
+
+
+class InvalidWinner(Exception):
+    pass
+
+
 async def create_match(db: AsyncSession, player1_id: int, player2_id: int) -> Match:
     match = Match(
         player1_id=player1_id,
@@ -189,6 +201,95 @@ async def finish_match(
     await db.commit()
     await db.refresh(match)
     return match
+
+
+async def record_tournament_match_result(
+    db: AsyncSession,
+    tournament_id: int,
+    match_id: int,
+    winner_id: int,
+    score_p1: int = 0,
+    score_p2: int = 0,
+) -> tuple[Tournament, bool]:
+    """Record the winner of a tournament match and advance the bracket.
+
+    Returns (tournament, tournament_complete).
+    """
+    result = await db.execute(
+        select(Tournament).where(Tournament.id == tournament_id).with_for_update()
+    )
+    tournament = result.scalars().first()
+    if tournament is None:
+        raise TournamentNotFound()
+
+    tm_result = await db.execute(
+        select(TournamentMatch).where(
+            TournamentMatch.tournament_id == tournament_id,
+            TournamentMatch.match_id == match_id,
+        )
+    )
+    tm = tm_result.scalars().first()
+    if tm is None:
+        raise TournamentMatchNotFound()
+    if tm.status == "finished":
+        raise TournamentMatchAlreadyFinished()
+    if winner_id not in (tm.player1_id, tm.player2_id):
+        raise InvalidWinner()
+
+    tm.winner_id = winner_id
+    tm.status = "finished"
+
+    match_result = await db.execute(select(Match).where(Match.id == match_id))
+    match = match_result.scalars().first()
+    if match is not None:
+        match.winner_id = winner_id
+        match.score_p1 = score_p1
+        match.score_p2 = score_p2
+        match.status = "finished"
+        match.finished_at = datetime.now(timezone.utc)
+
+    current_round = tm.round
+    round_result = await db.execute(
+        select(TournamentMatch)
+        .where(
+            TournamentMatch.tournament_id == tournament_id,
+            TournamentMatch.round == current_round,
+        )
+        .order_by(TournamentMatch.position)
+    )
+    round_matches = list(round_result.scalars().all())
+
+    tournament_complete = False
+    if all(rm.status == "finished" for rm in round_matches):
+        if len(round_matches) == 1:
+            tournament.status = "complete"
+            tournament_complete = True
+        else:
+            for i in range(len(round_matches) // 2):
+                w1 = round_matches[i * 2].winner_id
+                w2 = round_matches[i * 2 + 1].winner_id
+                new_match = Match(
+                    player1_id=w1,
+                    player2_id=w2,
+                    status="ongoing",
+                    started_at=datetime.now(timezone.utc),
+                )
+                db.add(new_match)
+                await db.flush()
+                new_tm = TournamentMatch(
+                    tournament_id=tournament_id,
+                    match_id=new_match.id,
+                    round=current_round + 1,
+                    position=i,
+                    player1_id=w1,
+                    player2_id=w2,
+                    status="pending",
+                )
+                db.add(new_tm)
+
+    await db.commit()
+    await db.refresh(tournament)
+    return tournament, tournament_complete
 
 
 async def get_match(db: AsyncSession, match_id: int) -> Match | None:

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -6,8 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from service.auth import get_current_user_id
 from service.history import get_match_history
 from service.persistence import (
+    InvalidWinner,
     NotTournamentCreator,
     TournamentFull,
+    TournamentMatchAlreadyFinished,
+    TournamentMatchNotFound,
     TournamentNotEnoughParticipants,
     TournamentNotFound,
     TournamentNotOpen,
@@ -21,6 +24,7 @@ from service.persistence import (
     get_user_matches,
     get_user_stats,
     join_tournament,
+    record_tournament_match_result,
     start_tournament,
 )
 from service.schemas import (
@@ -29,6 +33,7 @@ from service.schemas import (
     MatchFinishRequest,
     MatchHistoryItem,
     MatchResponse,
+    TournamentMatchResultRequest,
     StatsResponse,
     TournamentCreateRequest,
     TournamentCreateResponse,
@@ -162,6 +167,54 @@ async def start_tournament_endpoint(
     )
 
     return response
+
+
+@router.post(
+    "/tournaments/{tournament_id}/matches/{match_id}/result",
+    response_model=TournamentDetailResponse,
+)
+async def record_tournament_match_result_endpoint(
+    tournament_id: int,
+    match_id: int,
+    body: TournamentMatchResultRequest,
+    session: SessionDependency,
+    user_id: int = Depends(get_current_user_id),
+):
+    try:
+        _, tournament_complete = await record_tournament_match_result(
+            session, tournament_id, match_id, body.winner_id, body.score_p1, body.score_p2
+        )
+    except TournamentNotFound:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tournament not found")
+    except TournamentMatchNotFound:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Match not found in this tournament")
+    except TournamentMatchAlreadyFinished:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Match already finished")
+    except InvalidWinner:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="winner_id must be one of the match players")
+
+    await ws_manager.broadcast(
+        f"tournament_{tournament_id}",
+        {"type": "tournament_updated", "tournament_id": tournament_id},
+    )
+    if tournament_complete:
+        await ws_manager.broadcast(
+            f"tournament_{tournament_id}",
+            {"type": "tournament_complete", "tournament_id": tournament_id},
+        )
+
+    result = await get_tournament_with_participants(session, tournament_id)
+    tournament, participants, matches = result
+    return TournamentDetailResponse(
+        id=tournament.id,
+        name=tournament.name,
+        creator_id=tournament.creator_id,
+        max_participants=tournament.max_participants,
+        status=tournament.status,
+        created_at=tournament.created_at,
+        participants=[TournamentParticipantResponse(user_id=p.user_id, joined_at=p.joined_at) for p in participants],
+        matches=[TournamentMatchResponse.model_validate(m) for m in matches],
+    )
 
 
 @router.post("/matches/{match_id}/finish", response_model=MatchResponse)

--- a/src/backend/game-service/schemas.py
+++ b/src/backend/game-service/schemas.py
@@ -51,6 +51,12 @@ class MatchFinishRequest(BaseModel):
     score_p2: int
 
 
+class TournamentMatchResultRequest(BaseModel):
+    winner_id: int
+    score_p1: int = 0
+    score_p2: int = 0
+
+
 class MatchHistoryItem(BaseModel):
     id: int
     opponent_id: int

--- a/src/backend/game-service/tests/test_persistence.py
+++ b/src/backend/game-service/tests/test_persistence.py
@@ -5,18 +5,47 @@ from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sess
 from sqlalchemy.pool import NullPool
 
 from shared.config.settings import settings
-from persistence import create_match, finish_match, get_leaderboard, get_match, get_user_stats, get_user_matches
+from persistence import (
+    InvalidWinner,
+    TournamentMatchAlreadyFinished,
+    TournamentMatchNotFound,
+    TournamentNotFound,
+    create_match,
+    create_tournament,
+    finish_match,
+    get_leaderboard,
+    get_match,
+    get_tournament_with_participants,
+    get_user_matches,
+    get_user_stats,
+    join_tournament,
+    record_tournament_match_result,
+    start_tournament,
+)
 
 
 @pytest_asyncio.fixture
 async def db():
     engine = create_async_engine(settings.SQLALCHEMY_DATABASE_URI, poolclass=NullPool)
     async with engine.begin() as conn:
-        await conn.execute(text("TRUNCATE TABLE matches RESTART IDENTITY CASCADE"))
+        await conn.execute(
+            text(
+                "TRUNCATE TABLE tournament_matches, tournament_participants, "
+                "tournaments, matches RESTART IDENTITY CASCADE"
+            )
+        )
     Session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
     async with Session() as session:
         yield session
     await engine.dispose()
+
+
+async def _setup_tournament(db, max_participants: int):
+    tournament = await create_tournament(db, name="t", creator_id=1, max_participants=max_participants)
+    for uid in range(1, max_participants + 1):
+        await join_tournament(db, tournament.id, uid)
+    _, matches = await start_tournament(db, tournament.id, user_id=1)
+    return tournament, matches
 
 
 @pytest.mark.asyncio
@@ -148,6 +177,115 @@ async def test_get_leaderboard_orders_by_points_then_goal_difference(db):
     assert leaderboard[2]["user_id"] == 3
     assert leaderboard[2]["points"] == 0
     assert leaderboard[2]["rank"] == 3
+
+
+@pytest.mark.asyncio
+async def test_record_match_result_marks_finished_and_no_advance_when_round_incomplete(db):
+    tournament, r1 = await _setup_tournament(db, 4)
+    first = r1[0]
+    _, complete = await record_tournament_match_result(
+        db, tournament.id, first.match_id, winner_id=first.player1_id
+    )
+    assert complete is False
+    _, _, all_matches = await get_tournament_with_participants(db, tournament.id)
+    finished = [m for m in all_matches if m.status == "finished"]
+    assert len(finished) == 1
+    assert finished[0].winner_id == first.player1_id
+    # No new round yet
+    assert all(m.round == 1 for m in all_matches)
+
+
+@pytest.mark.asyncio
+async def test_record_match_result_persists_scores_on_match_row(db):
+    tournament, r1 = await _setup_tournament(db, 4)
+    first = r1[0]
+    await record_tournament_match_result(
+        db, tournament.id, first.match_id, winner_id=first.player1_id, score_p1=7, score_p2=3
+    )
+    match = await get_match(db, first.match_id)
+    assert match.status == "finished"
+    assert match.winner_id == first.player1_id
+    assert match.score_p1 == 7
+    assert match.score_p2 == 3
+
+
+@pytest.mark.asyncio
+async def test_record_match_result_advances_to_next_round_when_round_complete(db):
+    tournament, r1 = await _setup_tournament(db, 4)
+    winners = [m.player1_id for m in r1]
+    for m in r1:
+        await record_tournament_match_result(db, tournament.id, m.match_id, m.player1_id)
+
+    _, _, all_matches = await get_tournament_with_participants(db, tournament.id)
+    round2 = [m for m in all_matches if m.round == 2]
+    assert len(round2) == 1
+    assert {round2[0].player1_id, round2[0].player2_id} == set(winners)
+    assert round2[0].status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_record_match_result_completes_tournament_on_final(db):
+    tournament, r1 = await _setup_tournament(db, 4)
+    for m in r1:
+        await record_tournament_match_result(db, tournament.id, m.match_id, m.player1_id)
+    _, _, all_matches = await get_tournament_with_participants(db, tournament.id)
+    final = next(m for m in all_matches if m.round == 2)
+    _, complete = await record_tournament_match_result(
+        db, tournament.id, final.match_id, winner_id=final.player1_id
+    )
+    assert complete is True
+    t, _, _ = await get_tournament_with_participants(db, tournament.id)
+    assert t.status == "complete"
+
+
+@pytest.mark.asyncio
+async def test_record_match_result_8_player_full_bracket(db):
+    tournament, r1 = await _setup_tournament(db, 8)
+    for m in r1:
+        await record_tournament_match_result(db, tournament.id, m.match_id, m.player1_id)
+    _, _, all_matches = await get_tournament_with_participants(db, tournament.id)
+    r2 = [m for m in all_matches if m.round == 2]
+    assert len(r2) == 2
+    for m in r2:
+        await record_tournament_match_result(db, tournament.id, m.match_id, m.player1_id)
+    _, _, all_matches = await get_tournament_with_participants(db, tournament.id)
+    r3 = [m for m in all_matches if m.round == 3]
+    assert len(r3) == 1
+    _, complete = await record_tournament_match_result(
+        db, tournament.id, r3[0].match_id, winner_id=r3[0].player1_id
+    )
+    assert complete is True
+    t, _, _ = await get_tournament_with_participants(db, tournament.id)
+    assert t.status == "complete"
+
+
+@pytest.mark.asyncio
+async def test_record_match_result_invalid_winner(db):
+    tournament, r1 = await _setup_tournament(db, 4)
+    with pytest.raises(InvalidWinner):
+        await record_tournament_match_result(db, tournament.id, r1[0].match_id, winner_id=99999)
+
+
+@pytest.mark.asyncio
+async def test_record_match_result_already_finished(db):
+    tournament, r1 = await _setup_tournament(db, 4)
+    await record_tournament_match_result(db, tournament.id, r1[0].match_id, r1[0].player1_id)
+    with pytest.raises(TournamentMatchAlreadyFinished):
+        await record_tournament_match_result(db, tournament.id, r1[0].match_id, r1[0].player1_id)
+
+
+@pytest.mark.asyncio
+async def test_record_match_result_unknown_tournament(db):
+    with pytest.raises(TournamentNotFound):
+        await record_tournament_match_result(db, 99999, 1, winner_id=1)
+
+
+@pytest.mark.asyncio
+async def test_record_match_result_match_not_in_tournament(db):
+    tournament, _ = await _setup_tournament(db, 4)
+    other = await create_match(db, player1_id=50, player2_id=51)
+    with pytest.raises(TournamentMatchNotFound):
+        await record_tournament_match_result(db, tournament.id, other.id, winner_id=50)
 
 
 @pytest.mark.asyncio

--- a/src/backend/request.http
+++ b/src/backend/request.http
@@ -116,3 +116,14 @@ Authorization: Bearer <access_token>
 ### Start tournament (creator only — replace 1 with tournament id, replace <access_token>)
 POST https://localhost:8443/api/game/tournaments/1/start HTTP/1.1
 Authorization: Bearer <access_token>
+
+### Record tournament match result (replace 1 with tournament id, 1 with match id, replace <access_token>)
+POST https://localhost:8443/api/game/tournaments/1/matches/1/result HTTP/1.1
+content-type: application/json
+Authorization: Bearer <access_token>
+
+{
+    "winner_id": 1,
+    "score_p1": 3,
+    "score_p2": 5
+}


### PR DESCRIPTION
-Currently the "/tournaments/{tournament_id}/matches/{match_id}/result" endpoint works with any token, need to discuss if we limit to players/creator token.

Closes #185 
