### PR TITLE
297 back tournament 51   active match ready flow to waiting room

### DIFF
--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -56,6 +56,9 @@ class TournamentCannotBeCancelled(Exception):
 class TournamentNotParticipant(Exception):
     pass
 
+class TournamentNotInProgress(Exception):
+    pass
+
 async def delete_tournament(
     db: AsyncSession,
     tournament_id: int,
@@ -144,6 +147,81 @@ async def leave_tournament(
             await db.delete(tournament)
 
     await db.commit()
+
+async def withdraw_tournament(
+    db: AsyncSession,
+    tournament_id: int,
+    user_id: int,
+) -> tuple[Tournament, bool]:
+    result = await db.execute(
+        select(Tournament).where(Tournament.id == tournament_id).with_for_update()
+    )
+    tournament = result.scalars().first()
+
+    if tournament is None:
+        raise TournamentNotFound()
+
+    if tournament.status != "in_progress":
+        raise TournamentNotInProgress()
+
+    participant_result = await db.execute(
+        select(TournamentParticipant).where(
+            TournamentParticipant.tournament_id == tournament_id,
+            TournamentParticipant.user_id == user_id,
+        )
+    )
+    participant = participant_result.scalars().first()
+
+    if participant is None:
+        raise TournamentNotParticipant()
+
+    affected_matches_result = await db.execute(
+        select(TournamentMatch)
+        .where(
+            TournamentMatch.tournament_id == tournament_id,
+            or_(
+                TournamentMatch.player1_id == user_id,
+                TournamentMatch.player2_id == user_id,
+            ),
+        )
+        .order_by(TournamentMatch.position.asc(), TournamentMatch.id.asc())
+    )
+    affected_matches = list(affected_matches_result.scalars().all())
+
+    for tournament_match in affected_matches:
+        await _award_tournament_forfeit(db, tournament_match, user_id)
+
+    other_participants_result = await db.execute(
+        select(TournamentParticipant)
+        .where(
+            TournamentParticipant.tournament_id == tournament_id,
+            TournamentParticipant.user_id != user_id,
+        )
+        .order_by(TournamentParticipant.joined_at.asc())
+    )
+    other_participants = list(other_participants_result.scalars().all())
+
+    await db.delete(participant)
+    await db.flush()
+
+    if tournament.creator_id == user_id and other_participants:
+        tournament.creator_id = other_participants[0].user_id
+
+    await _assign_available_tournament_matches(db, tournament_id)
+
+    all_matches_result = await db.execute(
+        select(TournamentMatch).where(TournamentMatch.tournament_id == tournament_id)
+    )
+    all_matches = list(all_matches_result.scalars().all())
+
+    tournament_complete = all(match.status == "finished" for match in all_matches)
+
+    if tournament_complete:
+        tournament.status = "complete"
+
+    await db.commit()
+    await db.refresh(tournament)
+    return tournament, tournament_complete
 
 async def create_tournament(
     db: AsyncSession, name: str, creator_id: int, max_participants: int
@@ -263,6 +341,103 @@ async def join_tournament(
     await db.refresh(participant)
     return participant
 
+def _build_round_robin_pairs(user_ids: list[int]) -> list[tuple[int, int]]:
+    pairs: list[tuple[int, int]] = []
+
+    for i in range(len(user_ids)):
+        for j in range(i + 1, len(user_ids)):
+            pairs.append((user_ids[i], user_ids[j]))
+
+    return pairs
+
+
+async def _assign_available_tournament_matches(
+    db: AsyncSession,
+    tournament_id: int,
+) -> list[TournamentMatch]:
+    result = await db.execute(
+        select(TournamentMatch)
+        .where(TournamentMatch.tournament_id == tournament_id)
+        .order_by(TournamentMatch.position.asc(), TournamentMatch.id.asc())
+    )
+    tournament_matches = list(result.scalars().all())
+
+    busy_player_ids: set[int] = set()
+    for tm in tournament_matches:
+        if tm.status == "in_progress":
+            if tm.player1_id is not None:
+                busy_player_ids.add(tm.player1_id)
+            if tm.player2_id is not None:
+                busy_player_ids.add(tm.player2_id)
+
+    newly_assigned: list[TournamentMatch] = []
+
+    for tm in tournament_matches:
+        if tm.status != "pending":
+            continue
+
+        if tm.player1_id is None or tm.player2_id is None:
+            continue
+
+        if tm.player1_id in busy_player_ids or tm.player2_id in busy_player_ids:
+            continue
+
+        match = Match(
+            player1_id=tm.player1_id,
+            player2_id=tm.player2_id,
+            status="ongoing",
+            started_at=datetime.now(timezone.utc),
+        )
+        db.add(match)
+        await db.flush()
+
+        tm.match_id = match.id
+        tm.status = "in_progress"
+
+        busy_player_ids.add(tm.player1_id)
+        busy_player_ids.add(tm.player2_id)
+        newly_assigned.append(tm)
+
+    return newly_assigned
+
+async def _award_tournament_forfeit(
+    db: AsyncSession,
+    tournament_match: TournamentMatch,
+    withdrawn_user_id: int,
+) -> None:
+    if tournament_match.status == "finished":
+        return
+
+    if tournament_match.player1_id == withdrawn_user_id:
+        opponent_id = tournament_match.player2_id
+    elif tournament_match.player2_id == withdrawn_user_id:
+        opponent_id = tournament_match.player1_id
+    else:
+        return
+
+    tournament_match.winner_id = opponent_id
+    tournament_match.status = "finished"
+
+    if tournament_match.match_id is None:
+        return
+
+    match_result = await db.execute(
+        select(Match).where(Match.id == tournament_match.match_id)
+    )
+    match = match_result.scalars().first()
+    if match is None:
+        return
+
+    match.winner_id = opponent_id
+    if opponent_id == match.player1_id:
+        match.score_p1 = 1
+        match.score_p2 = 0
+    else:
+        match.score_p1 = 0
+        match.score_p2 = 1
+
+    match.status = "finished"
+    match.finished_at = datetime.now(timezone.utc)
 
 async def start_tournament(
     db: AsyncSession, tournament_id: int, user_id: int
@@ -284,44 +459,46 @@ async def start_tournament(
         )
     )
     participants = list(participants_result.scalars().all())
+
     if len(participants) != tournament.max_participants:
         raise TournamentNotEnoughParticipants()
 
-    random.shuffle(participants)
+    user_ids = [p.user_id for p in participants]
+    random.shuffle(user_ids)
+
+    pairings = _build_round_robin_pairs(user_ids)
 
     tournament_matches: list[TournamentMatch] = []
-    num_matches = tournament.max_participants // 2
-    for i in range(num_matches):
-        p1 = participants[i * 2]
-        p2 = participants[i * 2 + 1]
-
-        match = Match(
-            player1_id=p1.user_id,
-            player2_id=p2.user_id,
-            status="ongoing",
-            started_at=datetime.now(timezone.utc),
-        )
-        db.add(match)
-        await db.flush()
-
+    for position, (player1_id, player2_id) in enumerate(pairings):
         tm = TournamentMatch(
             tournament_id=tournament_id,
-            match_id=match.id,
+            match_id=None,
             round=1,
-            position=i,
-            player1_id=p1.user_id,
-            player2_id=p2.user_id,
+            position=position,
+            player1_id=player1_id,
+            player2_id=player2_id,
+            winner_id=None,
             status="pending",
         )
         db.add(tm)
         tournament_matches.append(tm)
 
     tournament.status = "in_progress"
+    await db.flush()
+
+    await _assign_available_tournament_matches(db, tournament_id)
+
     await db.commit()
-    for tm in tournament_matches:
-        await db.refresh(tm)
+
+    refreshed_result = await db.execute(
+        select(TournamentMatch)
+        .where(TournamentMatch.tournament_id == tournament_id)
+        .order_by(TournamentMatch.position.asc(), TournamentMatch.id.asc())
+    )
+    refreshed_matches = list(refreshed_result.scalars().all())
+
     await db.refresh(tournament)
-    return tournament, tournament_matches
+    return tournament, refreshed_matches
 
 
 async def finish_match(
@@ -349,10 +526,6 @@ async def record_tournament_match_result(
     score_p1: int = 0,
     score_p2: int = 0,
 ) -> tuple[Tournament, bool]:
-    """Record the winner of a tournament match and advance the bracket.
-
-    Returns (tournament, tournament_complete).
-    """
     result = await db.execute(
         select(Tournament).where(Tournament.id == tournament_id).with_for_update()
     )
@@ -386,44 +559,20 @@ async def record_tournament_match_result(
         match.status = "finished"
         match.finished_at = datetime.now(timezone.utc)
 
-    current_round = tm.round
-    round_result = await db.execute(
-        select(TournamentMatch)
-        .where(
-            TournamentMatch.tournament_id == tournament_id,
-            TournamentMatch.round == current_round,
-        )
-        .order_by(TournamentMatch.position)
-    )
-    round_matches = list(round_result.scalars().all())
+    await _assign_available_tournament_matches(db, tournament_id)
 
-    tournament_complete = False
-    if all(rm.status == "finished" for rm in round_matches):
-        if len(round_matches) == 1:
-            tournament.status = "complete"
-            tournament_complete = True
-        else:
-            for i in range(len(round_matches) // 2):
-                w1 = round_matches[i * 2].winner_id
-                w2 = round_matches[i * 2 + 1].winner_id
-                new_match = Match(
-                    player1_id=w1,
-                    player2_id=w2,
-                    status="ongoing",
-                    started_at=datetime.now(timezone.utc),
-                )
-                db.add(new_match)
-                await db.flush()
-                new_tm = TournamentMatch(
-                    tournament_id=tournament_id,
-                    match_id=new_match.id,
-                    round=current_round + 1,
-                    position=i,
-                    player1_id=w1,
-                    player2_id=w2,
-                    status="pending",
-                )
-                db.add(new_tm)
+    all_matches_result = await db.execute(
+        select(TournamentMatch).where(TournamentMatch.tournament_id == tournament_id)
+    )
+    all_matches = list(all_matches_result.scalars().all())
+
+    tournament_complete = all(
+        tournament_match.status == "finished"
+        for tournament_match in all_matches
+    )
+
+    if tournament_complete:
+        tournament.status = "complete"
 
     await db.commit()
     await db.refresh(tournament)

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -32,6 +32,8 @@ from service.persistence import (
     delete_tournament,
     TournamentNotParticipant,
     leave_tournament,
+    TournamentNotInProgress,
+    withdraw_tournament,
 )
 from service.schemas import (
     LeaderboardEntryResponse,
@@ -173,6 +175,61 @@ async def leave_tournament_endpoint(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="User is not a participant in this tournament",
         )
+
+@router.post(
+    "/tournaments/{tournament_id}/withdraw",
+    response_model=TournamentDetailResponse,
+)
+async def withdraw_tournament_endpoint(
+    tournament_id: int,
+    session: SessionDependency,
+    user_id: int = Depends(get_current_user_id),
+):
+    try:
+        _, tournament_complete = await withdraw_tournament(session, tournament_id, user_id)
+    except TournamentNotFound:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tournament not found",
+        )
+    except TournamentNotInProgress:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Only tournaments in progress can be withdrawn from",
+        )
+    except TournamentNotParticipant:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User is not a participant in this tournament",
+        )
+
+    await ws_manager.broadcast(
+        f"tournament_{tournament_id}",
+        {"type": "tournament_updated", "tournament_id": tournament_id},
+    )
+
+    if tournament_complete:
+        await ws_manager.broadcast(
+            f"tournament_{tournament_id}",
+            {"type": "tournament_complete", "tournament_id": tournament_id},
+        )
+
+    result = await get_tournament_with_participants(session, tournament_id)
+    tournament, participants, matches = result
+
+    return TournamentDetailResponse(
+        id=tournament.id,
+        name=tournament.name,
+        creator_id=tournament.creator_id,
+        max_participants=tournament.max_participants,
+        status=tournament.status,
+        created_at=tournament.created_at,
+        participants=[
+            TournamentParticipantResponse(user_id=p.user_id, joined_at=p.joined_at)
+            for p in participants
+        ],
+        matches=[TournamentMatchResponse.model_validate(m) for m in matches],
+    )
 
 @router.delete("/tournaments/{tournament_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_tournament_endpoint(

--- a/src/backend/game-service/schemas.py
+++ b/src/backend/game-service/schemas.py
@@ -67,7 +67,7 @@ class MatchHistoryItem(BaseModel):
 
 class TournamentCreateRequest(BaseModel):
     name: str
-    max_participants: int = Field(ge=3, le=8)
+    max_participants: int = Field(ge=4, le=8)
 
 
 class TournamentCreateResponse(BaseModel):

--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -2,13 +2,13 @@
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from jose import jwt
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 
 from shared.config.settings import settings
 from shared.ws.manager import ConnectionManager
 from shared.database import AsyncSessionLocal
 from service.persistence import create_match, finish_match, get_tournament_with_participants
 from service.game_manager import game_manager
-from sqlalchemy.exc import SQLAlchemyError
 
 router = APIRouter()
 manager = ConnectionManager()
@@ -18,10 +18,15 @@ _setup_sessions: dict[str, tuple[int, int]] = {}
 # Maps game_id (str) → match_id (int) for database updates
 _match_ids: dict[str, int] = {}
 
+_waiting_room_ready: dict[str, set[int]] = {}
+_waiting_room_players: dict[str, tuple[int, int]] = {}
+_tournament_ready: dict[tuple[int, int], set[int]] = {}
+_tournament_waiting_rooms: dict[tuple[int, int], str] = {}
+
 
 async def _broadcast_state(game_id: str, state_snapshot: dict) -> None:
     """Broadcast game state to both clients in a session.
-    
+
     Args:
         game_id: Unique game identifier
         state_snapshot: GameStateSnapshot serialized to dict with:
@@ -29,9 +34,50 @@ async def _broadcast_state(game_id: str, state_snapshot: dict) -> None:
     """
     msg = {
         "type": "state",
-        **state_snapshot  # Flatten snapshot: ball, paddles, score at top level
+        **state_snapshot,  # Flatten snapshot: ball, paddles, score at top level
     }
     await manager.broadcast(game_id, msg)
+
+
+def _cleanup_waiting_room(game_id: str) -> None:
+    _waiting_room_ready.pop(game_id, None)
+    _waiting_room_players.pop(game_id, None)
+
+
+async def _ensure_game_session(
+    game_id: str,
+    player1_id: int,
+    player2_id: int,
+    existing_match_id: int | None = None,
+) -> None:
+    _setup_sessions[game_id] = (player1_id, player2_id)
+
+    if game_manager.get_session(game_id):
+        if existing_match_id is not None and game_id not in _match_ids:
+            _match_ids[game_id] = existing_match_id
+        return
+
+    try:
+        await game_manager.create_session(
+            game_id,
+            player1_id,
+            player2_id,
+            broadcast_callback=_broadcast_state,
+            on_game_over_callback=_on_game_over,
+        )
+
+        if existing_match_id is not None:
+            _match_ids[game_id] = existing_match_id
+            return
+
+        async with AsyncSessionLocal() as db:
+            match = await create_match(db, player1_id, player2_id)
+            _match_ids[game_id] = match.id
+
+    except ValueError:
+        # Session already exists
+        if existing_match_id is not None and game_id not in _match_ids:
+            _match_ids[game_id] = existing_match_id
 
 
 async def _on_game_over(game_id: str, winner_id: int, score_p1: int, score_p2: int) -> None:
@@ -45,7 +91,7 @@ async def _on_game_over(game_id: str, winner_id: int, score_p1: int, score_p2: i
                     match_id,
                     winner_id,
                     score_p1,
-                    score_p2
+                    score_p2,
                 )
     except SQLAlchemyError:
         pass  # best-effort
@@ -54,25 +100,29 @@ async def _on_game_over(game_id: str, winner_id: int, score_p1: int, score_p2: i
         await game_manager.delete_session(game_id)
         _setup_sessions.pop(game_id, None)
         _match_ids.pop(game_id, None)
-        
+        _cleanup_waiting_room(game_id)
+
         # Broadcast the game over event authoritatively
-        await manager.broadcast(game_id, {
-            "type": "game_over",
-            "winner_id": winner_id,
-            "score_p1": score_p1,
-            "score_p2": score_p2
-        })
+        await manager.broadcast(
+            game_id,
+            {
+                "type": "game_over",
+                "winner_id": winner_id,
+                "score_p1": score_p1,
+                "score_p2": score_p2,
+            },
+        )
 
 
 @router.websocket("/ws/game/{game_id}")
 async def game_websocket(websocket: WebSocket, game_id: str, token: str | None = None) -> None:
     """
     WebSocket handler for in-game communication during a Pong match.
-    
+
     Protocol:
     - Client → Server: {"type": "input", "direction": "up"|"down"|"stop", "client_ts": <ms>}
     - Server → Client: {"type": "state", "ball": {...}, "paddles": {...}, "score": {...}}
-    
+
     The game loop runs independently in game_manager and broadcasts state
     to all connected clients each tick. This handler only processes inputs.
     """
@@ -82,12 +132,16 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
         client_host = websocket.client.host if websocket.client else ""
         healthcheck_token = token  # Reuse token param for healthcheck auth
         is_local = client_host in ("127.0.0.1", "localhost", "::1")
-        is_authorized = is_local or (healthcheck_token == settings.HEALTHCHECK_TOKEN if hasattr(settings, 'HEALTHCHECK_TOKEN') else False)
-        
+        is_authorized = is_local or (
+            healthcheck_token == settings.HEALTHCHECK_TOKEN
+            if hasattr(settings, "HEALTHCHECK_TOKEN")
+            else False
+        )
+
         if not is_authorized:
             await websocket.close(code=4003, reason="Healthcheck access denied")
             return
-        
+
         try:
             await websocket.accept()
             # Send one "ok" response and close — don't relay or broadcast
@@ -111,12 +165,12 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
         if credential_id is None:
             await websocket.close(code=4001)
             return
-            
+
         # Resolve credential_id -> user.id (Hybrid Pattern Fast Path)
         async with AsyncSessionLocal() as db:
             result = await db.execute(
                 text("SELECT id FROM users WHERE credential_id = :cid"),
-                {"cid": credential_id}
+                {"cid": credential_id},
             )
             row = result.fetchone()
             if not row:
@@ -127,86 +181,167 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
         await websocket.close(code=4001)
         return
 
-    # Accept the connection
     await manager.connect(game_id, websocket)
-    
+
     try:
         while True:
-            # Receive message from client
             data = await websocket.receive_json()
-            
+
             if not isinstance(data, dict):
                 continue
-            
+
             event_type = data.get("type")
-            
-            # Handle game_start: initialize game session
-            if event_type == "game_start":
+
+            if event_type == "player_ready":
+                event_user_id = data.get("user_id")
                 player1_id = data.get("player1_id")
                 player2_id = data.get("player2_id")
-                
+                existing_match_id = data.get("match_id")
+
+                if event_user_id != player_id:
+                    continue
+
                 if not isinstance(player1_id, int) or not isinstance(player2_id, int):
                     continue
-                
-                # Verify the authenticated user is part of this game
+
                 if player_id not in (player1_id, player2_id):
                     continue
-                
-                # Check if this is a new game or joining an existing setup
-                if game_id not in _setup_sessions:
-                    # This is the first player to connect
-                    _setup_sessions[game_id] = (player1_id, player2_id)
-                
-                # Once both players are ready or we have the info, create the session
-                p1, p2 = _setup_sessions[game_id]
-                
-                # Start the authoritative game loop if not already started
-                if not game_manager.get_session(game_id):
-                    try:
-                        await game_manager.create_session(
-                            game_id,
-                            p1,
-                            p2,
-                            broadcast_callback=_broadcast_state,
-                            on_game_over_callback=_on_game_over,
-                        )
-                        # Create database match record
-                        try:
-                            async with AsyncSessionLocal() as db:
-                                match = await create_match(db, p1, p2)
-                                # Store for later reference when game ends
-                                _match_ids[game_id] = match.id
-                        except SQLAlchemyError:
-                            pass  # best-effort
-                    except ValueError:
-                        # Game already exists, that's fine
-                        pass
-            
-            # Handle player input (with latency filtering)
+
+                if not isinstance(existing_match_id, int):
+                    existing_match_id = None
+
+                stored_players = _waiting_room_players.get(game_id)
+                if stored_players is None:
+                    _waiting_room_players[game_id] = (player1_id, player2_id)
+                else:
+                    player1_id, player2_id = stored_players
+
+                ready_set = _waiting_room_ready.setdefault(game_id, set())
+                ready_set.add(player_id)
+
+                await manager.broadcast(
+                    game_id,
+                    {
+                        "type": "player_ready",
+                        "room_id": game_id,
+                        "user_id": player_id,
+                        "player1_id": player1_id,
+                        "player2_id": player2_id,
+                    },
+                )
+
+                if len(ready_set) == 2:
+                    await _ensure_game_session(
+                        game_id,
+                        player1_id,
+                        player2_id,
+                        existing_match_id=existing_match_id,
+                    )
+
+                    await manager.broadcast(
+                        game_id,
+                        {
+                            "type": "game_start",
+                            "room_id": game_id,
+                            "player1_id": player1_id,
+                            "player2_id": player2_id,
+                            "match_id": _match_ids.get(game_id),
+                        },
+                    )
+
+            elif event_type == "player_unready":
+                event_user_id = data.get("user_id")
+                if event_user_id != player_id:
+                    continue
+
+                ready_set = _waiting_room_ready.setdefault(game_id, set())
+                ready_set.discard(player_id)
+
+                if not ready_set:
+                    _waiting_room_ready.pop(game_id, None)
+
+                await manager.broadcast(
+                    game_id,
+                    {
+                        "type": "player_unready",
+                        "room_id": game_id,
+                        "user_id": player_id,
+                    },
+                )
+
+            elif event_type == "cancel_waiting_room":
+                event_user_id = data.get("user_id")
+                if event_user_id != player_id:
+                    continue
+
+                _cleanup_waiting_room(game_id)
+
+                await manager.broadcast(
+                    game_id,
+                    {
+                        "type": "cancel_waiting_room",
+                        "room_id": game_id,
+                        "user_id": player_id,
+                    },
+                )
+
+            elif event_type == "game_start":
+                player1_id = data.get("player1_id")
+                player2_id = data.get("player2_id")
+                existing_match_id = data.get("match_id")
+
+                if not isinstance(player1_id, int) or not isinstance(player2_id, int):
+                    continue
+
+                if player_id not in (player1_id, player2_id):
+                    continue
+
+                if not isinstance(existing_match_id, int):
+                    existing_match_id = None
+
+                await _ensure_game_session(
+                    game_id,
+                    player1_id,
+                    player2_id,
+                    existing_match_id=existing_match_id,
+                )
+
             elif event_type == "input":
-                # Get the session
                 session = game_manager.get_session(game_id)
                 if session:
-                    # Process input using verified DB player_id
                     await game_manager.handle_player_input(game_id, player_id, data)
-            
-            # Pass-through other events (e.g., player_ready, player_unready, cancel_waiting_room)
+
             else:
                 await manager.broadcast(game_id, data)
-    
+
     except WebSocketDisconnect:
-        # Client disconnected
         pass
-    
+
     finally:
-        # Clean up on disconnect
         manager.disconnect(game_id, websocket)
-        
-        # If this was the last player, end the game
+
         if manager.active_connections(game_id) == 0:
-            await game_manager.delete_session(game_id)
-            _setup_sessions.pop(game_id, None)
-            _match_ids.pop(game_id, None)
+            _cleanup_waiting_room(game_id)
+
+            if not game_manager.get_session(game_id):
+                _setup_sessions.pop(game_id, None)
+                _match_ids.pop(game_id, None)
+
+
+def _clear_tournament_ready_for_user(tournament_id: int, user_id: int) -> None:
+    empty_keys: list[tuple[int, int]] = []
+
+    for key, ready_set in _tournament_ready.items():
+        if key[0] != tournament_id:
+            continue
+
+        ready_set.discard(user_id)
+        if not ready_set:
+            empty_keys.append(key)
+
+    for key in empty_keys:
+        _tournament_ready.pop(key, None)
+        _tournament_waiting_rooms.pop(key, None)
 
 
 @router.websocket("/ws/tournament/{tournament_id}")
@@ -258,11 +393,13 @@ async def tournament_websocket(
     await manager.connect(room_id, websocket)
 
     try:
-        await websocket.send_json({
-            "type": "tournament_connected",
-            "tournament_id": tournament_id,
-            "user_id": player_id,
-        })
+        await websocket.send_json(
+            {
+                "type": "tournament_connected",
+                "tournament_id": tournament_id,
+                "user_id": player_id,
+            },
+        )
 
         while True:
             data = await websocket.receive_json()
@@ -274,23 +411,94 @@ async def tournament_websocket(
             match_id = data.get("match_id")
 
             if event_type == "ready" and isinstance(match_id, int):
-                await manager.broadcast(room_id, {
-                    "type": "match_player_ready",
-                    "tournament_id": tournament_id,
-                    "match_id": match_id,
-                    "user_id": player_id,
-                })
+                async with AsyncSessionLocal() as db:
+                    tournament_data = await get_tournament_with_participants(db, tournament_id)
+                    if tournament_data is None:
+                        continue
+
+                    _, _, matches = tournament_data
+                    tournament_match = next(
+                        (m for m in matches if int(m.id) == int(match_id)),
+                        None,
+                    )
+
+                if tournament_match is None:
+                    continue
+
+                if tournament_match.status != "in_progress":
+                    continue
+
+                if tournament_match.match_id is None:
+                    continue
+
+                if player_id not in (
+                    tournament_match.player1_id,
+                    tournament_match.player2_id,
+                ):
+                    continue
+
+                ready_key = (tournament_id, int(tournament_match.id))
+                ready_set = _tournament_ready.setdefault(ready_key, set())
+                ready_set.add(player_id)
+
+                await manager.broadcast(
+                    room_id,
+                    {
+                        "type": "match_player_ready",
+                        "tournament_id": tournament_id,
+                        "match_id": int(tournament_match.id),
+                        "user_id": player_id,
+                    },
+                )
+
+                both_ready = (
+                    tournament_match.player1_id in ready_set
+                    and tournament_match.player2_id in ready_set
+                )
+
+                if both_ready:
+                    game_room_id = _tournament_waiting_rooms.get(ready_key)
+                    if not game_room_id:
+                        game_room_id = (
+                            f"tournament-{tournament_id}-match-{tournament_match.match_id}"
+                        )
+                        _tournament_waiting_rooms[ready_key] = game_room_id
+
+                    await manager.broadcast(
+                        room_id,
+                        {
+                            "type": "match_start",
+                            "tournament_id": tournament_id,
+                            "tournament_match_id": int(tournament_match.id),
+                            "match_id": int(tournament_match.match_id),
+                            "game_room_id": game_room_id,
+                            "player1_id": int(tournament_match.player1_id),
+                            "player2_id": int(tournament_match.player2_id),
+                        },
+                    )
 
             elif event_type == "unready" and isinstance(match_id, int):
-                await manager.broadcast(room_id, {
-                    "type": "match_player_unready",
-                    "tournament_id": tournament_id,
-                    "match_id": match_id,
-                    "user_id": player_id,
-                })
+                ready_key = (tournament_id, int(match_id))
+                ready_set = _tournament_ready.setdefault(ready_key, set())
+                ready_set.discard(player_id)
+
+                if not ready_set:
+                    _tournament_ready.pop(ready_key, None)
+                    _tournament_waiting_rooms.pop(ready_key, None)
+
+                await manager.broadcast(
+                    room_id,
+                    {
+                        "type": "match_player_unready",
+                        "tournament_id": tournament_id,
+                        "match_id": int(match_id),
+                        "user_id": player_id,
+                    },
+                )
 
     except WebSocketDisconnect:
         pass
 
     finally:
+        _clear_tournament_ready_for_user(tournament_id, player_id)
         manager.disconnect(room_id, websocket)

--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 from shared.config.settings import settings
 from shared.ws.manager import ConnectionManager
 from shared.database import AsyncSessionLocal
-from service.persistence import create_match, finish_match
+from service.persistence import create_match, finish_match, get_tournament_with_participants
 from service.game_manager import game_manager
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -207,3 +207,90 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
             await game_manager.delete_session(game_id)
             _setup_sessions.pop(game_id, None)
             _match_ids.pop(game_id, None)
+
+
+@router.websocket("/ws/tournament/{tournament_id}")
+async def tournament_websocket(
+    websocket: WebSocket,
+    tournament_id: int,
+    token: str | None = None,
+) -> None:
+    if not token:
+        await websocket.close(code=4001)
+        return
+
+    try:
+        payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=["HS256"])
+        credential_id = payload.get("credential_id")
+        if credential_id is None:
+            await websocket.close(code=4001)
+            return
+
+        async with AsyncSessionLocal() as db:
+            result = await db.execute(
+                text("SELECT id FROM users WHERE credential_id = :cid"),
+                {"cid": credential_id},
+            )
+            row = result.fetchone()
+            if not row:
+                await websocket.close(code=4001)
+                return
+
+            player_id = row[0]
+
+            tournament_data = await get_tournament_with_participants(db, tournament_id)
+            if tournament_data is None:
+                await websocket.close(code=4004)
+                return
+
+            _, participants, _ = tournament_data
+            participant_ids = {p.user_id for p in participants}
+
+            if player_id not in participant_ids:
+                await websocket.close(code=4003)
+                return
+
+    except Exception:
+        await websocket.close(code=4001)
+        return
+
+    room_id = f"tournament_{tournament_id}"
+    await manager.connect(room_id, websocket)
+
+    try:
+        await websocket.send_json({
+            "type": "tournament_connected",
+            "tournament_id": tournament_id,
+            "user_id": player_id,
+        })
+
+        while True:
+            data = await websocket.receive_json()
+
+            if not isinstance(data, dict):
+                continue
+
+            event_type = data.get("type")
+            match_id = data.get("match_id")
+
+            if event_type == "ready" and isinstance(match_id, int):
+                await manager.broadcast(room_id, {
+                    "type": "match_player_ready",
+                    "tournament_id": tournament_id,
+                    "match_id": match_id,
+                    "user_id": player_id,
+                })
+
+            elif event_type == "unready" and isinstance(match_id, int):
+                await manager.broadcast(room_id, {
+                    "type": "match_player_unready",
+                    "tournament_id": tournament_id,
+                    "match_id": match_id,
+                    "user_id": player_id,
+                })
+
+    except WebSocketDisconnect:
+        pass
+
+    finally:
+        manager.disconnect(room_id, websocket)

--- a/src/frontend/src/pages/GameWaitingRoom.jsx
+++ b/src/frontend/src/pages/GameWaitingRoom.jsx
@@ -23,7 +23,7 @@ export default function GameWaitingRoom() {
   const wsRef = useRef(null)
 
   const hasInviteContext = Boolean(
-    location.state?.currentUser || location.state?.opponent || location.state?.friendUsername
+    location.state?.currentUser || location.state?.opponent || location.state?.friendUsername,
   )
 
   const currentUser = useMemo(() => (
@@ -41,6 +41,29 @@ export default function GameWaitingRoom() {
       avatarUrl: DEFAULT_AVATAR,
     })
   ), [location.state])
+
+  const [canonicalPlayer1Id, canonicalPlayer2Id] = useMemo(() => {
+    const stateP1 = Number(location.state?.player1_id)
+    const stateP2 = Number(location.state?.player2_id)
+
+    if (Number.isInteger(stateP1) && Number.isInteger(stateP2)) {
+      return [stateP1, stateP2]
+    }
+
+    const a = Number(currentUser.id)
+    const b = Number(opponent.id)
+
+    if (Number.isInteger(a) && Number.isInteger(b)) {
+      return a <= b ? [a, b] : [b, a]
+    }
+
+    return [null, null]
+  }, [location.state, currentUser.id, opponent.id])
+
+  const existingMatchId = useMemo(() => {
+    const matchId = Number(location.state?.matchId ?? location.state?.match_id)
+    return Number.isInteger(matchId) ? matchId : null
+  }, [location.state])
 
   const [connected, setConnected] = useState(false)
   const [currentReady, setCurrentReady] = useState(false)
@@ -66,8 +89,9 @@ export default function GameWaitingRoom() {
         setSystemMessage('Connection lost. Trying to reconnect...')
       },
       onMessage: (data) => {
-        if (!data || typeof data !== 'object')
+        if (!data || typeof data !== 'object') {
           return
+        }
 
         const incomingUserId = String(data.user_id ?? data.player_id ?? '')
         const isCurrentUser = incomingUserId && incomingUserId === String(currentUser.id)
@@ -89,7 +113,17 @@ export default function GameWaitingRoom() {
 
         if (data.type === 'game_start') {
           setGameStartReceived(true)
-          setSystemMessage('Both players are ready. Game start event received.')
+          setSystemMessage('Both players are ready. Starting match...')
+
+          navigate(`/game/${roomId}`, {
+            replace: true,
+            state: {
+              ...location.state,
+              player1_id: data.player1_id ?? canonicalPlayer1Id,
+              player2_id: data.player2_id ?? canonicalPlayer2Id,
+              matchId: data.match_id ?? existingMatchId,
+            },
+          })
         }
       },
     })
@@ -97,7 +131,17 @@ export default function GameWaitingRoom() {
     wsRef.current = ws
 
     return () => ws.close()
-  }, [roomId, currentUser.id, opponent.id, navigate, auth?.access_token])
+  }, [
+    roomId,
+    currentUser.id,
+    opponent.id,
+    navigate,
+    auth?.access_token,
+    location.state,
+    canonicalPlayer1Id,
+    canonicalPlayer2Id,
+    existingMatchId,
+  ])
 
   useEffect(() => {
     if (currentReady && opponentReady && !gameStartReceived) {
@@ -106,8 +150,14 @@ export default function GameWaitingRoom() {
   }, [currentReady, opponentReady, gameStartReceived])
 
   function handleReady() {
-    if (currentReady || !wsRef.current)
+    if (currentReady || !wsRef.current) {
       return
+    }
+
+    if (!Number.isInteger(canonicalPlayer1Id) || !Number.isInteger(canonicalPlayer2Id)) {
+      setSystemMessage('Missing player ids for this room.')
+      return
+    }
 
     setCurrentReady(true)
     setSystemMessage('You are ready. Waiting for the other player...')
@@ -115,8 +165,11 @@ export default function GameWaitingRoom() {
     wsRef.current.send({
       type: 'player_ready',
       room_id: roomId,
-      user_id: currentUser.id,
+      user_id: Number(currentUser.id),
       username: currentUser.username,
+      player1_id: canonicalPlayer1Id,
+      player2_id: canonicalPlayer2Id,
+      match_id: existingMatchId,
     })
   }
 
@@ -124,8 +177,11 @@ export default function GameWaitingRoom() {
     wsRef.current?.send({
       type: 'cancel_waiting_room',
       room_id: roomId,
-      user_id: currentUser.id,
+      user_id: Number(currentUser.id),
       username: currentUser.username,
+      player1_id: canonicalPlayer1Id,
+      player2_id: canonicalPlayer2Id,
+      match_id: existingMatchId,
     })
 
     navigate('/play')

--- a/src/frontend/src/pages/Tournament.jsx
+++ b/src/frontend/src/pages/Tournament.jsx
@@ -1,50 +1,73 @@
-import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import NavbarComponent from '../Components/Navbar'
-import { useAuth } from '../context/authContext'
 import { apiCall, apiJson } from '../utils/apiClient'
+import { useAuth } from '../context/authContext'
+import { createWsClient } from '../utils/wsClient'
+import './Tournament.css'
 
-/**
- * Tournaments hub
- *
- * This page allows authenticated users to create new tournaments and join
- * existing ones. Because the backend currently exposes no endpoint to
- * list all tournaments, this component maintains a local list of
- * tournaments the current user creates or joins. After creating a
- * tournament, details are fetched from the server so participant counts
- * and status remain accurate. Users can join open tournaments that have
- * not yet reached their participant capacity and view the tournament by
- * navigating to the tournament detail page. Once a proper tournaments
- * listing endpoint is available, this page can be extended to fetch
- * tournaments from the backend instead of relying on local state.
- */
-export default function Tournaments() {
+export default function Tournament() {
+  const { id: tournamentId } = useParams()
   const navigate = useNavigate()
   const { auth } = useAuth()
-  const [currentUser, setCurrentUser] = useState(null)
-  const [loadingUser, setLoadingUser] = useState(true)
-  const [tournaments, setTournaments] = useState([])
-  const [name, setName] = useState('')
-  const [maxParticipants, setMaxParticipants] = useState('4')
-  const [creating, setCreating] = useState(false)
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [tournament, setTournament] = useState(null)
+  const [profiles, setProfiles] = useState({})
+  const [currentUser, setCurrentUser] = useState(null)
+  const wsRef = useRef(null)
 
-  // Track whether the current user is already registered in an active tournament (open or in progress).
-  const [hasActiveTournament, setHasActiveTournament] = useState(false)
+  const isCreator = useMemo(() => {
+    return currentUser && tournament && Number(currentUser.id) === Number(tournament.creator_id)
+  }, [currentUser, tournament])
 
-  // Track an id to manually add/join a tournament by id. This allows other
-  // users to join tournaments created elsewhere when they know the id.
-  const [manualId, setManualId] = useState('')
-  const [joiningById, setJoiningById] = useState(false)
+  const isJoined = useMemo(() => {
+    return currentUser && tournament && tournament.participants?.some(
+      (p) => Number(p.user_id) === Number(currentUser.id),
+    )
+  }, [currentUser, tournament])
 
-  // Fetch the authenticated user's info once to know their id.
+  const leaderboard = useMemo(() => {
+    if (!tournament || !tournament.participants) return []
+
+    const stats = {}
+
+    tournament.participants.forEach(({ user_id }) => {
+      stats[user_id] = { userId: user_id, wins: 0, matches: 0 }
+    })
+
+    if (tournament.matches) {
+      tournament.matches.forEach((m) => {
+        if (m.player1_id != null && stats[m.player1_id]) stats[m.player1_id].matches++
+        if (m.player2_id != null && stats[m.player2_id]) stats[m.player2_id].matches++
+        if (m.status === 'finished' && m.winner_id != null && stats[m.winner_id]) {
+          stats[m.winner_id].wins++
+        }
+      })
+    }
+
+    const entries = Object.values(stats).map((s) => {
+      const prof = profiles[s.userId] || {}
+      return {
+        userId: s.userId,
+        username: prof.username || `User ${s.userId}`,
+        avatarUrl: prof.avatarUrl || '/avatar_placeholder.jpg',
+        wins: s.wins,
+        matches: s.matches,
+        points: s.wins,
+      }
+    })
+
+    entries.sort((a, b) => b.points - a.points)
+    return entries
+  }, [tournament, profiles])
+
   useEffect(() => {
     let cancelled = false
 
     async function loadMe() {
       if (!auth?.access_token) {
         setCurrentUser(null)
-        setLoadingUser(false)
         return
       }
 
@@ -55,8 +78,6 @@ export default function Tournaments() {
         if (!cancelled) setCurrentUser({ id: data.id, username: data.username })
       } catch {
         if (!cancelled) setCurrentUser(null)
-      } finally {
-        if (!cancelled) setLoadingUser(false)
       }
     }
 
@@ -64,383 +85,377 @@ export default function Tournaments() {
     return () => { cancelled = true }
   }, [auth?.access_token])
 
-  // Helper to fetch a tournament's full details and merge into local state
-  async function fetchAndStoreTournament(id) {
-    try {
-      const resp = await apiCall(`/api/game/tournaments/${id}`)
-      if (!resp.ok) throw new Error('Failed to load tournament details')
-      const data = await resp.json()
+  useEffect(() => {
+    if (!tournamentId) return
+    let cancelled = false
 
-      setTournaments((prev) => {
-        const idx = prev.findIndex((t) => t.id === data.id)
-        if (idx >= 0) {
-          const updated = [...prev]
-          updated[idx] = data
-          return updated
+    async function fetchTournament() {
+      setLoading(true)
+      setError('')
+
+      try {
+        const resp = await apiCall(`/api/game/tournaments/${tournamentId}`)
+        if (!resp.ok) {
+          if (resp.status === 404) throw new Error('Tournament not found')
+          throw new Error('Failed to load tournament')
         }
-        return [...prev, data]
-      })
 
-      return data
-    } catch (err) {
-      console.error(err)
-      setError(err.message || 'Failed to load tournament details')
-    }
-  }
+        const data = await resp.json()
+        if (cancelled) return
+        setTournament(data)
 
-  async function loadTournaments() {
-  try {
-    setError('')
-    const resp = await apiCall('/api/game/tournaments')
-    if (!resp.ok) throw new Error('Failed to load tournaments')
-    const data = await resp.json()
-    setTournaments(Array.isArray(data) ? data : [])
-  } catch (err) {
-    setError(err.message || 'Failed to load tournaments')
-  }
-}
+        const uniqueUserIds = [...new Set(data.participants.map((p) => p.user_id))]
+        const profileEntries = {}
 
-  // Create a new tournament via the backend and fetch its details
-  async function handleCreate(e) {
-    e.preventDefault()
-    if (!name || creating) return
-
-    if (hasActiveTournament) {
-      setError('You are already registered in an active tournament. You cannot create another one right now.')
-      return
-    }
-
-    setError('')
-    setCreating(true)
-
-    try {
-      const slots = Number(maxParticipants)
-        if (slots < 4 || slots > 8) {
-          throw new Error('Tournament size must be between 4 and 8 players')
-      }
-
-      const body = { name, max_participants: slots }
-      const data = await apiJson('/api/game/tournaments', {
-        method: 'POST',
-        body: JSON.stringify(body),
-      })
-
-      if (data?.id) {
-        await loadTournaments()
-      }
-
-      setName('')
-      setMaxParticipants('4')
-    } catch (err) {
-      setError(err.message || 'Failed to create tournament')
-    } finally {
-      setCreating(false)
-    }
-  }
-
-  async function handleLeave(id) {
-  setError('')
-  try {
-    await apiJson(`/api/game/tournaments/${id}/leave`, { method: 'POST' })
-    await loadTournaments()
-  } catch (err) {
-    setError(err.message || 'Failed to leave tournament')
-  }
-}
-
-  // Join a tournament and refresh its details
-  async function handleJoin(id) {
-    setError('')
-
-    if (hasActiveTournament) {
-      const existing = tournaments.find((t) => t.id === id)
-      const alreadyJoined = existing?.participants?.some(
-        (p) => Number(p.user_id) === Number(currentUser?.id),
-      )
-
-      if (!alreadyJoined) {
-        setError('You are already registered in an active tournament. You cannot join another one right now.')
-        return
-      }
-    }
-
-    try {
-      await apiJson(`/api/game/tournaments/${id}/join`, {
-        method: 'POST',
-      })
-
-      const data = await fetchAndStoreTournament(id)
-      await loadTournaments()
-      if (data && data.participants && data.participants.length === data.max_participants) {
-        navigate(`/tournaments/${id}`)
-      }
-    } catch (err) {
-      setError(err.message || 'Failed to join tournament')
-    }
-  }
-
-  // Manually join a tournament by entering its id.
-  async function handleJoinById(e) {
-    e.preventDefault()
-    const idNum = Number(manualId)
-    if (!idNum || joiningById) return
-
-    setError('')
-    setJoiningById(true)
-
-    try {
-      if (hasActiveTournament) {
-        const existing = tournaments.find((t) => t.id === idNum)
-        const alreadyJoinedExisting = existing?.participants?.some(
-          (p) => Number(p.user_id) === Number(currentUser?.id),
+        await Promise.all(
+          uniqueUserIds.map(async (uid) => {
+            try {
+              const res = await apiCall(`/api/users/profile/${uid}`)
+              if (!res.ok) throw new Error('Profile fetch failed')
+              const p = await res.json()
+              profileEntries[uid] = {
+                username: p.display_name || p.username || `User ${uid}`,
+                avatarUrl: p.avatar_url || '/avatar_placeholder.jpg',
+              }
+            } catch {
+              profileEntries[uid] = {
+                username: `User ${uid}`,
+                avatarUrl: '/avatar_placeholder.jpg',
+              }
+            }
+          }),
         )
 
-        if (!alreadyJoinedExisting) {
-          setError('You are already registered in an active tournament. You cannot join another one right now.')
-          return
+        if (!cancelled) setProfiles(profileEntries)
+      } catch (err) {
+        if (!cancelled) setError(err.message)
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    fetchTournament()
+    return () => { cancelled = true }
+  }, [tournamentId])
+
+  useEffect(() => {
+    if (!tournamentId || !auth?.access_token) return
+
+    const scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const url = `${scheme}//${window.location.host}/api/game/ws/tournament/${tournamentId}?token=${auth.access_token}`
+
+    const ws = createWsClient(url, {
+      onMessage: async (data) => {
+        if (!data || typeof data !== 'object') return
+
+        const { type, tournament_id } = data
+        if (
+          (type === 'tournament_updated' || type === 'tournament_complete') &&
+          String(tournament_id) === String(tournamentId)
+        ) {
+          try {
+            const resp = await apiCall(`/api/game/tournaments/${tournamentId}`)
+            if (!resp.ok) return
+
+            const freshData = await resp.json()
+            setTournament(freshData)
+
+            const ids = freshData.participants.map((p) => p.user_id)
+            const missingIds = ids.filter((uid) => !profiles[uid])
+
+            if (missingIds.length > 0) {
+              const newEntries = {}
+
+              await Promise.all(
+                missingIds.map(async (uid) => {
+                  try {
+                    const res = await apiCall(`/api/users/profile/${uid}`)
+                    if (!res.ok) throw new Error('Profile fetch failed')
+                    const p = await res.json()
+                    newEntries[uid] = {
+                      username: p.display_name || p.username || `User ${uid}`,
+                      avatarUrl: p.avatar_url || '/avatar_placeholder.jpg',
+                    }
+                  } catch {
+                    newEntries[uid] = {
+                      username: `User ${uid}`,
+                      avatarUrl: '/avatar_placeholder.jpg',
+                    }
+                  }
+                }),
+              )
+
+              setProfiles((prev) => ({ ...prev, ...newEntries }))
+            }
+          } catch {
+            // ignore websocket refresh errors
+          }
         }
-      }
+      },
+    })
 
-      const resp = await apiCall(`/api/game/tournaments/${idNum}`)
-      if (!resp.ok) {
-        if (resp.status === 404) throw new Error('Tournament not found')
-        throw new Error('Failed to fetch tournament')
-      }
+    wsRef.current = ws
+    return () => {
+      ws.close()
+    }
+  }, [tournamentId, auth?.access_token, profiles])
 
-      const data = await resp.json()
-      const joined = data.participants?.some(
-        (p) => Number(p.user_id) === Number(currentUser?.id),
-      )
+  const canStart = useMemo(() => {
+    if (!tournament || !currentUser) return false
+    return (
+      tournament.status === 'open' &&
+      tournament.participants?.length === tournament.max_participants &&
+      Number(currentUser.id) === Number(tournament.creator_id)
+    )
+  }, [tournament, currentUser])
 
-      if (!joined && data.status === 'open' && data.participants?.length < data.max_participants) {
-        await apiJson(`/api/game/tournaments/${idNum}/join`, { method: 'POST' })
-      }
+  async function handleStartTournament() {
+    if (!tournamentId) return
 
-      await fetchAndStoreTournament(idNum)
-      await loadTournaments()
-      setManualId('')
+    try {
+      const resp = await apiJson(`/api/game/tournaments/${tournamentId}/start`, {
+        method: 'POST',
+      })
+      setTournament(resp)
     } catch (err) {
-      setError(err.message || 'Could not join tournament')
-    } finally {
-      setJoiningById(false)
+      setError(err.message || 'Failed to start tournament')
     }
   }
 
-    useEffect(() => {
-      loadTournaments()
-    }, [])
+  async function handleLeave() {
+    if (!tournamentId) return
 
-  // Determine if the user already participates in any active tournament.
-  useEffect(() => {
-    if (!currentUser) {
-      setHasActiveTournament(false)
-      return
+    try {
+      await apiJson(`/api/game/tournaments/${tournamentId}/leave`, { method: 'POST' })
+      navigate('/tournaments', { replace: true })
+    } catch (err) {
+      setError(err.message || 'Failed to leave tournament')
     }
+  }
 
-    const active = tournaments.some((t) => {
-      const joined = t.participants?.some((p) => Number(p.user_id) === Number(currentUser.id))
-      return joined && (t.status === 'open' || t.status === 'in_progress')
-    })
+  async function handleCancel() {
+    if (!tournamentId) return
 
-    setHasActiveTournament(active)
-  }, [tournaments, currentUser])
+    try {
+      await apiJson(`/api/game/tournaments/${tournamentId}`, { method: 'DELETE' })
+      navigate('/tournaments', { replace: true })
+    } catch (err) {
+      setError(err.message || 'Failed to cancel tournament')
+    }
+  }
 
-  // When a tournament in which the current user participates reaches its maximum
-  // number of participants and is still open, automatically redirect to its page.
-  useEffect(() => {
-    if (!currentUser) return
+  const matchesByRound = useMemo(() => {
+    const map = {}
 
-    tournaments.forEach((t) => {
-      const joined = t.participants?.some((p) => Number(p.user_id) === Number(currentUser.id))
-      const isFull = (t.participants?.length || 0) === (t.max_participants || 0)
-      if (joined && isFull && t.status === 'open') {
-        navigate(`/tournaments/${t.id}`)
+    if (tournament?.matches) {
+      for (const m of tournament.matches) {
+        const r = m.round ?? 0
+        map[r] = map[r] || []
+        map[r].push(m)
       }
-    })
-  }, [tournaments, currentUser, navigate])
+    }
 
-  function handleView(id) {
-    navigate(`/tournaments/${id}`)
+    return Object.entries(map)
+      .sort((a, b) => Number(a[0]) - Number(b[0]))
+      .map(([round, list]) => ({
+        round: Number(round),
+        matches: list.sort((a, b) => a.position - b.position),
+      }))
+  }, [tournament])
+
+  function renderMatchCell(match) {
+    const { player1_id, player2_id, winner_id, status } = match
+    const p1 = player1_id != null ? profiles[player1_id] : null
+    const p2 = player2_id != null ? profiles[player2_id] : null
+    const winner = winner_id != null ? profiles[winner_id] : null
+
+    return (
+      <div
+        key={match.id || `${match.round}-${match.position}`}
+        className={`tournament-match-cell ${status === 'finished' ? 'finished' : ''}`}
+      >
+        <div className="tournament-player">
+          <img
+            src={p1?.avatarUrl || '/avatar_placeholder.jpg'}
+            alt="player1 avatar"
+            className="tournament-avatar"
+          />
+          <span className="tournament-player-name">{p1?.username || 'TBD'}</span>
+        </div>
+
+        <div className="tournament-vs">vs</div>
+
+        <div className="tournament-player">
+          <img
+            src={p2?.avatarUrl || '/avatar_placeholder.jpg'}
+            alt="player2 avatar"
+            className="tournament-avatar"
+          />
+          <span className="tournament-player-name">{p2?.username || 'TBD'}</span>
+        </div>
+
+        {status === 'finished' && (
+          <div className="tournament-winner">
+            Winner: <strong>{winner?.username || 'Unknown'}</strong>
+          </div>
+        )}
+      </div>
+    )
   }
 
-  function hasJoined(t) {
-    if (!currentUser || !t.participants) return false
-    return t.participants.some((p) => Number(p.user_id) === Number(currentUser.id))
+  if (loading) {
+    return (
+      <div className="arcade-shell">
+        <NavbarComponent />
+        <main className="arcade-content py-4">
+          <section className="arcade-screen">
+            <div className="arcade-panel p-4">
+              <p className="arcade-copy mb-0">Loading tournament…</p>
+            </div>
+          </section>
+        </main>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="arcade-shell">
+        <NavbarComponent />
+        <main className="arcade-content py-4">
+          <section className="arcade-screen">
+            <div className="arcade-panel p-4">
+              <p className="arcade-copy mb-0 text-danger">{error}</p>
+            </div>
+          </section>
+        </main>
+      </div>
+    )
   }
 
   return (
-    <div className="arcade-shell">
+    <div className="arcade-shell tournament-page">
       <NavbarComponent />
       <main className="arcade-content py-4">
         <section className="arcade-screen">
           <div className="arcade-panel p-4 p-lg-5">
             <div className="d-flex flex-column flex-lg-row justify-content-between align-items-lg-end gap-3 mb-4">
               <div>
-                <span className="arcade-display mb-3">Tournament hub</span>
-                <h1 className="arcade-title mb-2">Tournaments</h1>
+                <span className="arcade-display mb-3 d-inline-block">Tournament</span>
+                <h1 className="arcade-title mb-2">{tournament?.name || 'Tournament'}</h1>
                 <p className="arcade-copy mb-0">
-                  Create a new tournament or join an existing one. This view
-                  lists tournaments you have created or joined. Once a
-                  tournament is full, its creator can start it from the
-                  tournament page.
+                  {tournament?.participants?.length || 0} / {tournament?.max_participants} participants&nbsp;•&nbsp;
+                  Status: {tournament?.status}
                 </p>
+              </div>
+
+              <div className="d-flex flex-column align-items-start align-items-lg-end gap-2">
+                {tournament?.status === 'open' && isJoined && (
+                  <button
+                    type="button"
+                    className={`arcade-btn ${isCreator ? 'arcade-btn-danger' : 'arcade-btn-secondary'}`}
+                    onClick={isCreator ? handleCancel : handleLeave}
+                  >
+                    {isCreator ? 'Cancel Tournament' : 'Leave Tournament'}
+                  </button>
+                )}
+
+                {canStart && (
+                  <button
+                    type="button"
+                    className="arcade-btn arcade-btn-primary"
+                    onClick={handleStartTournament}
+                  >
+                    Start Tournament
+                  </button>
+                )}
+
+                <button
+                  type="button"
+                  className="arcade-btn arcade-btn-secondary"
+                  onClick={() => navigate('/tournaments')}
+                >
+                  Back to Tournaments
+                </button>
               </div>
             </div>
 
-            <div className="arcade-card soft p-4 mb-4">
-              <h2 className="arcade-section-title mb-3">Create new tournament</h2>
-              {hasActiveTournament && (
-                <p className="arcade-copy text-warning mb-2">
-                  You are currently registered in an active tournament. You cannot create or join another one right now.
-                </p>
-              )}
+            <div className="tournament-participants mb-4">
+              <h2 className="arcade-section-title mb-2">Participants</h2>
+              <div className="participant-grid">
+                {tournament?.participants?.map(({ user_id }) => {
+                  const prof = profiles[user_id] || {}
+                  return (
+                    <div className="participant-card" key={user_id}>
+                      <img
+                        src={prof.avatarUrl || '/avatar_placeholder.jpg'}
+                        alt={prof.username || `User ${user_id}`}
+                        className="participant-avatar"
+                      />
+                      <span className="participant-name">{prof.username || `User ${user_id}`}</span>
+                    </div>
+                  )
+                })}
 
-              <form onSubmit={handleCreate} className="row g-3 align-items-end">
-                <div className="col-12 col-sm-6 col-md-5">
-                  <label htmlFor="tournament-name" className="form-label">Name</label>
-                  <input
-                    id="tournament-name"
-                    type="text"
-                    className="form-control"
-                    placeholder="Enter tournament name"
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    required
-                  />
-                </div>
-
-                <div className="col-6 col-sm-3 col-md-2">
-                  <label htmlFor="tournament-size" className="form-label">Slots</label>
-                  <input
-                    id="tournament-size"
-                    type="number"
-                    className="form-control"
-                    list="tournament-size-options"
-                    value={maxParticipants}
-                    onChange={(e) => setMaxParticipants(e.target.value)}
-                    required
-                  />
-                  <datalist id="tournament-size-options">
-                    <option value="4" />
-                    <option value="8" />
-                  </datalist>
-                  <small className="form-text text-muted">Only 4 or 8 players are supported.</small>
-                </div>
-
-                <div className="col-6 col-sm-3 col-md-2">
-                  <button
-                    type="submit"
-                    className="arcade-btn arcade-btn-primary w-100"
-                    disabled={creating || !name || hasActiveTournament}
-                  >
-                    {creating ? 'Creating...' : 'Create'}
-                  </button>
-                </div>
-              </form>
-
-              {error && <p className="arcade-copy text-danger mt-2 mb-0">{error}</p>}
-
-              <hr className="my-4" />
-              <h2 className="arcade-section-title mb-3">Join by ID</h2>
-
-              <form onSubmit={handleJoinById} className="row g-3 align-items-end">
-                <div className="col-12 col-sm-6 col-md-5">
-                  <label htmlFor="manual-id" className="form-label">Tournament ID</label>
-                  <input
-                    id="manual-id"
-                    type="number"
-                    className="form-control"
-                    placeholder="Enter ID"
-                    value={manualId}
-                    onChange={(e) => setManualId(e.target.value)}
-                    min="1"
-                  />
-                </div>
-
-                <div className="col-6 col-sm-3 col-md-2">
-                  <button
-                    type="submit"
-                    className="arcade-btn arcade-btn-secondary w-100"
-                    disabled={joiningById || !manualId || hasActiveTournament}
-                  >
-                    {joiningById ? 'Processing...' : 'Join'}
-                  </button>
-                </div>
-              </form>
+                {Array.from({
+                  length: (tournament.max_participants || 0) - (tournament.participants?.length || 0),
+                }).map((_, idx) => (
+                  <div className="participant-card placeholder" key={`placeholder-${idx}`}>
+                    <div className="placeholder-avatar" />
+                    <span className="participant-name">Waiting…</span>
+                  </div>
+                ))}
+              </div>
             </div>
 
-            <div className="arcade-card soft p-4">
-              <h2 className="arcade-section-title mb-3">Tournaments</h2>
-
-              {loadingUser && <p className="arcade-copy mb-0">Loading...</p>}
-
-              {!loadingUser && tournaments.length === 0 && (
-                <p className="arcade-copy mb-0">No tournaments yet. Create one above.</p>
-              )}
-
-              {!loadingUser && tournaments.length > 0 && (
+            {leaderboard.length > 0 && (
+              <div className="tournament-leaderboard mb-4">
+                <h2 className="arcade-section-title mb-2">Leaderboard</h2>
                 <div className="table-responsive">
                   <table className="table table-dark table-striped align-middle">
                     <thead>
                       <tr>
-                        <th>Name</th>
-                        <th>Players</th>
-                        <th>Status</th>
-                        <th>Actions</th>
+                        <th>Player</th>
+                        <th>Wins</th>
+                        <th>Matches</th>
                       </tr>
                     </thead>
-
                     <tbody>
-                      {tournaments.map((t) => {
-                        const joined = hasJoined(t)
-                        const participantCount = t.participants?.length ?? 0
-                        const isFull = participantCount >= (t.max_participants || 0)
-                        const canJoin = !joined && t.status === 'open' && !isFull && !hasActiveTournament
-
-                        return (
-                          <tr key={t.id}>
-                            <td>{t.name || `Tournament ${t.id}`}</td>
-                            <td>{participantCount} / {t.max_participants}</td>
-                            <td>{t.status}</td>
-                            <td className="d-flex gap-2">
-                              {canJoin && (
-                                <button
-                                  type="button"
-                                  className="arcade-btn arcade-btn-secondary"
-                                  onClick={() => handleJoin(t.id)}
-                                >
-                                  Join
-                                </button>
-                              )}
-
-                              {joined && (
-                                <>
-                                  <span className="badge bg-success">Joined</span>
-                                  {t.status === 'open' && (
-                                    <button
-                                      type="button"
-                                      className="arcade-btn arcade-btn-secondary"
-                                      onClick={() => handleLeave(t.id)}
-                                    >
-                                      Leave
-                                    </button>
-                                  )}
-                                </>
-                              )}
-
-                              <button
-                                type="button"
-                                className="arcade-btn arcade-btn-ghost"
-                                onClick={() => handleView(t.id)}
-                              >
-                                View
-                              </button>
+                      {leaderboard.map((row) => (
+                        <tr key={row.userId}>
+                          <td className="d-flex align-items-center gap-2">
+                            <img
+                              src={row.avatarUrl || '/avatar_placeholder.jpg'}
+                              alt={row.username}
+                              style={{ width: '32px', height: '32px', borderRadius: '50%' }}
+                            />
+                            <span>{row.username}</span>
                           </td>
-                      </tr>
-                        )
-                      })}
+                          <td>{row.wins}</td>
+                          <td>{row.matches}</td>
+                        </tr>
+                      ))}
                     </tbody>
                   </table>
+                </div>
+              </div>
+            )}
+
+            <div className="tournament-bracket">
+              {matchesByRound.length === 0 && (
+                <p className="arcade-copy">No matches scheduled yet.</p>
+              )}
+
+              {matchesByRound.length > 0 && (
+                <div className="bracket-rounds">
+                  {matchesByRound.map(({ round, matches }) => (
+                    <div className="bracket-round" key={round}>
+                      <h3 className="arcade-section-title mb-3">Round {round}</h3>
+                      <div className="bracket-matches">
+                        {matches.map((match) => renderMatchCell(match))}
+                      </div>
+                    </div>
+                  ))}
                 </div>
               )}
             </div>

--- a/src/frontend/src/pages/Tournament.jsx
+++ b/src/frontend/src/pages/Tournament.jsx
@@ -10,11 +10,15 @@ export default function Tournament() {
   const { id: tournamentId } = useParams()
   const navigate = useNavigate()
   const { auth } = useAuth()
+
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
+  const [startError, setStartError] = useState('')
+  const [startLoading, setStartLoading] = useState(false)
   const [tournament, setTournament] = useState(null)
   const [profiles, setProfiles] = useState({})
   const [currentUser, setCurrentUser] = useState(null)
+
   const wsRef = useRef(null)
 
   const isCreator = useMemo(() => {
@@ -26,6 +30,18 @@ export default function Tournament() {
       (p) => Number(p.user_id) === Number(currentUser.id),
     )
   }, [currentUser, tournament])
+
+  const participantCount = tournament?.participants?.length ?? 0
+  const maxParticipants = tournament?.max_participants ?? 0
+
+  const showStartButton = useMemo(() => {
+    return Boolean(tournament && tournament.status === 'open' && isCreator)
+  }, [tournament, isCreator])
+
+  const canStart = useMemo(() => {
+    if (!showStartButton) return false
+    return participantCount === maxParticipants && !startLoading
+  }, [showStartButton, participantCount, maxParticipants, startLoading])
 
   const leaderboard = useMemo(() => {
     if (!tournament || !tournament.participants) return []
@@ -82,7 +98,9 @@ export default function Tournament() {
     }
 
     loadMe()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [auth?.access_token])
 
   useEffect(() => {
@@ -135,95 +153,92 @@ export default function Tournament() {
     }
 
     fetchTournament()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [tournamentId])
 
   useEffect(() => {
-  if (!tournamentId || !auth?.access_token) return
+    if (!tournamentId || !auth?.access_token) return
 
-  const scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-  const url = `${scheme}//${window.location.host}/api/game/ws/tournament/${tournamentId}?token=${auth.access_token}`
+    const scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+    const url = `${scheme}//${window.location.host}/api/game/ws/tournament/${tournamentId}?token=${auth.access_token}`
 
-  const ws = createWsClient(url, {
-    onOpen: () => {
-      console.log(`[Tournament WS] connected: ${tournamentId}`)
-    },
+    const ws = createWsClient(url, {
+      onOpen: () => {
+        console.log(`[Tournament WS] connected: ${tournamentId}`)
+      },
 
-    onClose: () => {
-      console.log(`[Tournament WS] disconnected: ${tournamentId}`)
-    },
+      onClose: () => {
+        console.log(`[Tournament WS] disconnected: ${tournamentId}`)
+      },
 
-    onMessage: async (data) => {
-      if (!data || typeof data !== 'object') return
+      onMessage: async (data) => {
+        if (!data || typeof data !== 'object') return
 
-      const { type, tournament_id } = data
+        const { type, tournament_id } = data
 
-      if (String(tournament_id) !== String(tournamentId)) return
+        if (String(tournament_id) !== String(tournamentId)) return
 
-      if (type === 'match_player_ready' || type === 'match_player_unready') {
-        console.log('[Tournament WS] readiness update:', data)
-        return
-      }
+        if (type === 'match_player_ready' || type === 'match_player_unready') {
+          console.log('[Tournament WS] readiness update:', data)
+          return
+        }
 
-      if (type !== 'tournament_updated' && type !== 'tournament_complete') {
-        return
-      }
+        if (type !== 'tournament_updated' && type !== 'tournament_complete') {
+          return
+        }
 
-      try {
-        const resp = await apiCall(`/api/game/tournaments/${tournamentId}`)
-        if (!resp.ok) return
+        try {
+          const resp = await apiCall(`/api/game/tournaments/${tournamentId}`)
+          if (!resp.ok) return
 
-        const freshData = await resp.json()
-        setTournament(freshData)
+          const freshData = await resp.json()
+          setTournament(freshData)
+          setStartError('')
 
-        const ids = [...new Set(freshData.participants.map((p) => p.user_id))]
-        const newEntries = {}
+          const ids = [...new Set(freshData.participants.map((p) => p.user_id))]
+          const newEntries = {}
 
-        await Promise.all(
-          ids.map(async (uid) => {
-            try {
-              const res = await apiCall(`/api/users/profile/${uid}`)
-              if (!res.ok) throw new Error('Profile fetch failed')
-              const p = await res.json()
+          await Promise.all(
+            ids.map(async (uid) => {
+              try {
+                const res = await apiCall(`/api/users/profile/${uid}`)
+                if (!res.ok) throw new Error('Profile fetch failed')
+                const p = await res.json()
 
-              newEntries[uid] = {
-                username: p.display_name || p.username || `User ${uid}`,
-                avatarUrl: p.avatar_url || '/avatar_placeholder.jpg',
+                newEntries[uid] = {
+                  username: p.display_name || p.username || `User ${uid}`,
+                  avatarUrl: p.avatar_url || '/avatar_placeholder.jpg',
+                }
+              } catch {
+                newEntries[uid] = {
+                  username: `User ${uid}`,
+                  avatarUrl: '/avatar_placeholder.jpg',
+                }
               }
-            } catch {
-              newEntries[uid] = {
-                username: `User ${uid}`,
-                avatarUrl: '/avatar_placeholder.jpg',
-              }
-            }
-          }),
-        )
+            }),
+          )
 
-        setProfiles((prev) => ({ ...prev, ...newEntries }))
-      } catch {
-        // ignore websocket refresh errors
-      }
-    },
-  })
+          setProfiles((prev) => ({ ...prev, ...newEntries }))
+        } catch {
+          // ignore websocket refresh errors
+        }
+      },
+    })
 
-  wsRef.current = ws
+    wsRef.current = ws
 
-  return () => {
-    ws.close()
-  }
-}, [tournamentId, auth?.access_token])
-
-  const canStart = useMemo(() => {
-    if (!tournament || !currentUser) return false
-    return (
-      tournament.status === 'open' &&
-      tournament.participants?.length === tournament.max_participants &&
-      Number(currentUser.id) === Number(tournament.creator_id)
-    )
-  }, [tournament, currentUser])
+    return () => {
+      ws.close()
+    }
+  }, [tournamentId, auth?.access_token])
 
   async function handleStartTournament() {
-    if (!tournamentId) return
+    if (!tournamentId || !canStart) return
+
+    setStartLoading(true)
+    setStartError('')
 
     try {
       const resp = await apiJson(`/api/game/tournaments/${tournamentId}/start`, {
@@ -231,7 +246,9 @@ export default function Tournament() {
       })
       setTournament(resp)
     } catch (err) {
-      setError(err.message || 'Failed to start tournament')
+      setStartError(err.message || 'Failed to start tournament')
+    } finally {
+      setStartLoading(false)
     }
   }
 
@@ -239,6 +256,7 @@ export default function Tournament() {
     if (!tournamentId) return
 
     try {
+      setError('')
       await apiJson(`/api/game/tournaments/${tournamentId}/leave`, { method: 'POST' })
       navigate('/tournaments', { replace: true })
     } catch (err) {
@@ -246,10 +264,25 @@ export default function Tournament() {
     }
   }
 
+  async function handleWithdraw() {
+    if (!tournamentId) return
+
+    try {
+      setError('')
+      await apiJson(`/api/game/tournaments/${tournamentId}/withdraw`, {
+        method: 'POST',
+      })
+      navigate('/tournaments', { replace: true })
+    } catch (err) {
+      setError(err.message || 'Failed to withdraw from tournament')
+    }
+  }
+
   async function handleCancel() {
     if (!tournamentId) return
 
     try {
+      setError('')
       await apiJson(`/api/game/tournaments/${tournamentId}`, { method: 'DELETE' })
       navigate('/tournaments', { replace: true })
     } catch (err) {
@@ -357,7 +390,7 @@ export default function Tournament() {
                 <span className="arcade-display mb-3 d-inline-block">Tournament</span>
                 <h1 className="arcade-title mb-2">{tournament?.name || 'Tournament'}</h1>
                 <p className="arcade-copy mb-0">
-                  {tournament?.participants?.length || 0} / {tournament?.max_participants} participants&nbsp;•&nbsp;
+                  {participantCount} / {maxParticipants} participants&nbsp;•&nbsp;
                   Status: {tournament?.status}
                 </p>
               </div>
@@ -372,14 +405,29 @@ export default function Tournament() {
                     {isCreator ? 'Cancel Tournament' : 'Leave Tournament'}
                   </button>
                 )}
+                {tournament?.status === 'in_progress' && isJoined && (
+                  <button
+                    type="button"
+                    className="arcade-btn arcade-btn-danger"
+                    onClick={handleWithdraw}
+                  >
+                    Withdraw from Tournament
+                  </button>
+                )}
 
-                {canStart && (
+                {showStartButton && (
                   <button
                     type="button"
                     className="arcade-btn arcade-btn-primary"
                     onClick={handleStartTournament}
+                    disabled={!canStart}
+                    title={
+                      !canStart
+                        ? `Tournament must be full to start (${participantCount}/${maxParticipants})`
+                        : ''
+                    }
                   >
-                    Start Tournament
+                    {startLoading ? 'Starting...' : 'Start Tournament'}
                   </button>
                 )}
 
@@ -392,6 +440,12 @@ export default function Tournament() {
                 </button>
               </div>
             </div>
+
+            {startError && (
+              <div className="alert alert-danger mb-4" role="alert">
+                {startError}
+              </div>
+            )}
 
             <div className="tournament-participants mb-4">
               <h2 className="arcade-section-title mb-2">Participants</h2>
@@ -411,7 +465,7 @@ export default function Tournament() {
                 })}
 
                 {Array.from({
-                  length: (tournament.max_participants || 0) - (tournament.participants?.length || 0),
+                  length: Math.max(0, maxParticipants - participantCount),
                 }).map((_, idx) => (
                   <div className="participant-card placeholder" key={`placeholder-${idx}`}>
                     <div className="placeholder-avatar" />

--- a/src/frontend/src/pages/Tournament.jsx
+++ b/src/frontend/src/pages/Tournament.jsx
@@ -139,66 +139,79 @@ export default function Tournament() {
   }, [tournamentId])
 
   useEffect(() => {
-    if (!tournamentId || !auth?.access_token) return
+  if (!tournamentId || !auth?.access_token) return
 
-    const scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-    const url = `${scheme}//${window.location.host}/api/game/ws/tournament/${tournamentId}?token=${auth.access_token}`
+  const scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const url = `${scheme}//${window.location.host}/api/game/ws/tournament/${tournamentId}?token=${auth.access_token}`
 
-    const ws = createWsClient(url, {
-      onMessage: async (data) => {
-        if (!data || typeof data !== 'object') return
+  const ws = createWsClient(url, {
+    onOpen: () => {
+      console.log(`[Tournament WS] connected: ${tournamentId}`)
+    },
 
-        const { type, tournament_id } = data
-        if (
-          (type === 'tournament_updated' || type === 'tournament_complete') &&
-          String(tournament_id) === String(tournamentId)
-        ) {
-          try {
-            const resp = await apiCall(`/api/game/tournaments/${tournamentId}`)
-            if (!resp.ok) return
+    onClose: () => {
+      console.log(`[Tournament WS] disconnected: ${tournamentId}`)
+    },
 
-            const freshData = await resp.json()
-            setTournament(freshData)
+    onMessage: async (data) => {
+      if (!data || typeof data !== 'object') return
 
-            const ids = freshData.participants.map((p) => p.user_id)
-            const missingIds = ids.filter((uid) => !profiles[uid])
+      const { type, tournament_id } = data
 
-            if (missingIds.length > 0) {
-              const newEntries = {}
+      if (String(tournament_id) !== String(tournamentId)) return
 
-              await Promise.all(
-                missingIds.map(async (uid) => {
-                  try {
-                    const res = await apiCall(`/api/users/profile/${uid}`)
-                    if (!res.ok) throw new Error('Profile fetch failed')
-                    const p = await res.json()
-                    newEntries[uid] = {
-                      username: p.display_name || p.username || `User ${uid}`,
-                      avatarUrl: p.avatar_url || '/avatar_placeholder.jpg',
-                    }
-                  } catch {
-                    newEntries[uid] = {
-                      username: `User ${uid}`,
-                      avatarUrl: '/avatar_placeholder.jpg',
-                    }
-                  }
-                }),
-              )
+      if (type === 'match_player_ready' || type === 'match_player_unready') {
+        console.log('[Tournament WS] readiness update:', data)
+        return
+      }
 
-              setProfiles((prev) => ({ ...prev, ...newEntries }))
+      if (type !== 'tournament_updated' && type !== 'tournament_complete') {
+        return
+      }
+
+      try {
+        const resp = await apiCall(`/api/game/tournaments/${tournamentId}`)
+        if (!resp.ok) return
+
+        const freshData = await resp.json()
+        setTournament(freshData)
+
+        const ids = [...new Set(freshData.participants.map((p) => p.user_id))]
+        const newEntries = {}
+
+        await Promise.all(
+          ids.map(async (uid) => {
+            try {
+              const res = await apiCall(`/api/users/profile/${uid}`)
+              if (!res.ok) throw new Error('Profile fetch failed')
+              const p = await res.json()
+
+              newEntries[uid] = {
+                username: p.display_name || p.username || `User ${uid}`,
+                avatarUrl: p.avatar_url || '/avatar_placeholder.jpg',
+              }
+            } catch {
+              newEntries[uid] = {
+                username: `User ${uid}`,
+                avatarUrl: '/avatar_placeholder.jpg',
+              }
             }
-          } catch {
-            // ignore websocket refresh errors
-          }
-        }
-      },
-    })
+          }),
+        )
 
-    wsRef.current = ws
-    return () => {
-      ws.close()
-    }
-  }, [tournamentId, auth?.access_token, profiles])
+        setProfiles((prev) => ({ ...prev, ...newEntries }))
+      } catch {
+        // ignore websocket refresh errors
+      }
+    },
+  })
+
+  wsRef.current = ws
+
+  return () => {
+    ws.close()
+  }
+}, [tournamentId, auth?.access_token])
 
   const canStart = useMemo(() => {
     if (!tournament || !currentUser) return false

--- a/src/frontend/src/pages/Tournament.jsx
+++ b/src/frontend/src/pages/Tournament.jsx
@@ -18,6 +18,7 @@ export default function Tournament() {
   const [tournament, setTournament] = useState(null)
   const [profiles, setProfiles] = useState({})
   const [currentUser, setCurrentUser] = useState(null)
+  const [readyByMatch, setReadyByMatch] = useState({})
 
   const wsRef = useRef(null)
 
@@ -180,8 +181,66 @@ export default function Tournament() {
 
         if (String(tournament_id) !== String(tournamentId)) return
 
-        if (type === 'match_player_ready' || type === 'match_player_unready') {
-          console.log('[Tournament WS] readiness update:', data)
+        if (type === 'match_player_ready') {
+          setReadyByMatch((prev) => ({
+            ...prev,
+            [data.match_id]: {
+              ...(prev[data.match_id] || {}),
+              [data.user_id]: true,
+            },
+          }))
+          return
+        }
+
+        if (type === 'match_player_unready') {
+          setReadyByMatch((prev) => {
+            const current = { ...(prev[data.match_id] || {}) }
+            delete current[data.user_id]
+
+            return {
+              ...prev,
+              [data.match_id]: current,
+            }
+          })
+          return
+        }
+
+        if (type === 'match_start') {
+          if (!currentUser) return
+
+          const isMyMatch =
+            Number(currentUser.id) === Number(data.player1_id) ||
+            Number(currentUser.id) === Number(data.player2_id)
+
+          if (!isMyMatch) return
+
+          const opponentId =
+            Number(currentUser.id) === Number(data.player1_id)
+              ? Number(data.player2_id)
+              : Number(data.player1_id)
+
+          const opponentProfile = profiles[opponentId] || {}
+
+          navigate(`/game/waiting/${data.game_room_id}`, {
+            replace: true,
+            state: {
+              currentUser: {
+                id: currentUser.id,
+                username: currentUser.username,
+                avatarUrl: profiles[currentUser.id]?.avatarUrl || '/avatar_placeholder.jpg',
+              },
+              opponent: {
+                id: opponentId,
+                username: opponentProfile.username || `User ${opponentId}`,
+                avatarUrl: opponentProfile.avatarUrl || '/avatar_placeholder.jpg',
+              },
+              player1_id: Number(data.player1_id),
+              player2_id: Number(data.player2_id),
+              matchId: Number(data.match_id),
+              tournamentId: Number(tournamentId),
+              tournamentMatchId: Number(data.tournament_match_id),
+            },
+          })
           return
         }
 
@@ -232,7 +291,7 @@ export default function Tournament() {
     return () => {
       ws.close()
     }
-  }, [tournamentId, auth?.access_token])
+  }, [tournamentId, auth?.access_token, currentUser, navigate, profiles])
 
   async function handleStartTournament() {
     if (!tournamentId || !canStart) return
@@ -290,6 +349,15 @@ export default function Tournament() {
     }
   }
 
+  function handleReadyForMatch(match) {
+    if (!wsRef.current || !match?.id) return
+
+    wsRef.current.send({
+      type: 'ready',
+      match_id: Number(match.id),
+    })
+  }
+
   const matchesByRound = useMemo(() => {
     const map = {}
 
@@ -315,6 +383,19 @@ export default function Tournament() {
     const p2 = player2_id != null ? profiles[player2_id] : null
     const winner = winner_id != null ? profiles[winner_id] : null
 
+    const isCurrentUsersMatch =
+      currentUser &&
+      status === 'in_progress' &&
+      (Number(player1_id) === Number(currentUser.id) ||
+        Number(player2_id) === Number(currentUser.id))
+
+    const currentUserReady = Boolean(readyByMatch[match.id]?.[currentUser?.id])
+
+    const opponentId =
+      Number(currentUser?.id) === Number(player1_id) ? player2_id : player1_id
+
+    const opponentIsReady = Boolean(readyByMatch[match.id]?.[opponentId])
+
     return (
       <div
         key={match.id || `${match.round}-${match.position}`}
@@ -339,6 +420,23 @@ export default function Tournament() {
           />
           <span className="tournament-player-name">{p2?.username || 'TBD'}</span>
         </div>
+
+        {isCurrentUsersMatch && (
+          <div className="mt-3 d-flex flex-column gap-2">
+            <button
+              type="button"
+              className="arcade-btn arcade-btn-primary"
+              onClick={() => handleReadyForMatch(match)}
+              disabled={currentUserReady}
+            >
+              {currentUserReady ? 'Ready locked' : 'Ready for Match'}
+            </button>
+
+            {opponentIsReady && (
+              <span className="arcade-copy">Opponent is ready.</span>
+            )}
+          </div>
+        )}
 
         {status === 'finished' && (
           <div className="tournament-winner">
@@ -405,6 +503,7 @@ export default function Tournament() {
                     {isCreator ? 'Cancel Tournament' : 'Leave Tournament'}
                   </button>
                 )}
+
                 {tournament?.status === 'in_progress' && isJoined && (
                   <button
                     type="button"

--- a/src/frontend/src/pages/Tournaments.jsx
+++ b/src/frontend/src/pages/Tournaments.jsx
@@ -4,13 +4,6 @@ import NavbarComponent from '../Components/Navbar'
 import { useAuth } from '../context/authContext'
 import { apiCall, apiJson } from '../utils/apiClient'
 
-/**
- * Tournaments hub
- *
- * This page allows authenticated users to create new tournaments and join
- * existing ones. Because the backend now exposes a listing endpoint,
- * this component loads tournaments directly from the game service.
- */
 export default function Tournaments() {
   const navigate = useNavigate()
   const { auth } = useAuth()
@@ -21,7 +14,6 @@ export default function Tournaments() {
   const [maxParticipants, setMaxParticipants] = useState('4')
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState('')
-
   const [hasActiveTournament, setHasActiveTournament] = useState(false)
   const [manualId, setManualId] = useState('')
   const [joiningById, setJoiningById] = useState(false)

--- a/src/frontend/src/pages/Tournaments.jsx
+++ b/src/frontend/src/pages/Tournaments.jsx
@@ -93,8 +93,8 @@ export default function Tournaments() {
 
     try {
       const slots = Number(maxParticipants)
-      if (![4, 8].includes(slots)) {
-        throw new Error('Tournament size must be 4 or 8 players')
+      if (slots < 4 || slots > 8) {
+        throw new Error('Tournament size must be between 4 and 8 players')
       }
 
       const body = { name, max_participants: slots }
@@ -299,16 +299,14 @@ export default function Tournaments() {
                     id="tournament-size"
                     type="number"
                     className="form-control"
-                    list="tournament-size-options"
+                    min="4"
+                    max="8"
+                    step="1"
                     value={maxParticipants}
                     onChange={(e) => setMaxParticipants(e.target.value)}
                     required
                   />
-                  <datalist id="tournament-size-options">
-                    <option value="4" />
-                    <option value="8" />
-                  </datalist>
-                  <small className="form-text text-muted">Only 4 or 8 players are supported.</small>
+                  <small className="form-text text-muted">Choose between 4 and 8 players.</small>
                 </div>
 
                 <div className="col-6 col-sm-3 col-md-2">


### PR DESCRIPTION
Partial delivery for parent issue #187.

This PR implements the tournament-to-waiting-room integration:
- active tournament matches can be readied up
- backend emits match_start when both players are ready
- both players are redirected to the shared waiting room
- in-progress tournament withdraw is supported with automatic forfeits

Remaining work in #187:
- complete in-game flow
- propagate final match result back into tournament state
- add tournament_invite notification support


Closes #297