### PR TITLE
236 back gamification 3   leaderboard endpoint

### DIFF
--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -551,7 +551,10 @@ def leaderboard_order_by_str(sort_assoc: list[tuple[str, str]] | None) -> str | 
 
 
 async def get_leaderboard_paginated(
-        db: AsyncSession, limit: int = 20, page: int = 0, sort_assoc: [(str, str)] = None
+        db: AsyncSession,
+        limit: int = 20,
+        page: int = 0,
+        sort_assoc: list[tuple[str, str]] = None
 ) -> dict | None:
     offset = page * limit
     default_sort_string = """
@@ -682,7 +685,8 @@ WITH all_matches AS
     SELECT
         users.id
         AS user_id
-        , users.display_name
+        , COALESCE(users.display_name, users.username)
+        AS display_name
         , sum(wins)
         AS wins
         , sum(losses)
@@ -727,32 +731,50 @@ WITH all_matches AS
 , summary AS
 (
     SELECT
-        (SELECT
+        COALESCE(
+            (SELECT
+                jsonb_build_object(
+                    'display_name', display_name,
+                    'value', max_streak
+                )
+             FROM ranking_results
+             ORDER BY max_streak DESC, {default_sort_string}
+             LIMIT 1),
             jsonb_build_object(
-                'display_name', display_name,
-                'value', max_streak
+                'display_name', 'No Data',
+                'value', 0
             )
-         FROM ranking_results
-         ORDER BY max_streak DESC, {default_sort_string}
-         LIMIT 1)
+        )
         AS max_max_streak
-        , (SELECT
+        , COALESCE(
+            (SELECT
+                jsonb_build_object(
+                    'display_name', display_name,
+                    'value', points
+                )
+             FROM ranking_results
+             ORDER BY {default_sort_string}
+             LIMIT 1),
             jsonb_build_object(
-                'display_name', display_name,
-                'value', points
+                'display_name', 'No Data',
+                'value', 0
             )
-         FROM ranking_results
-         ORDER BY {default_sort_string}
-         LIMIT 1)
+        )
         AS max_points
-        , (SELECT
+        , COALESCE(
+            (SELECT
+                jsonb_build_object(
+                    'display_name', display_name,
+                    'value', current_streak
+                )
+             FROM ranking_results
+             ORDER BY current_streak DESC, {default_sort_string}
+             LIMIT 1),
             jsonb_build_object(
-                'display_name', display_name,
-                'value', current_streak
+                'display_name', 'No Data',
+                'value', 0
             )
-         FROM ranking_results
-         ORDER BY current_streak DESC, {default_sort_string}
-         LIMIT 1)
+        )
         AS max_current_streak
 )
 , page_ranking_results AS (
@@ -765,9 +787,9 @@ WITH all_matches AS
             FROM user_count)
 )
 SELECT
-    LEAST(:page, ((table user_count) / :limit))
+    LEAST(:page, (((table user_count) - 1) / :limit))
     AS page
-    , ((table user_count) / :limit)
+    , (((table user_count) - 1) / :limit)
     AS last_page
     , :limit as per_page
     , (table user_count) as total

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -527,6 +527,131 @@ async def get_user_matches(db: AsyncSession, user_id: int) -> list[Match]:
     return list(result.scalars().all())
 
 
+async def get_leaderboard_pagginated(
+        db: AsyncSession, limit: int = 20, page: int = 0
+) -> dict | None:
+
+    offset = page * limit
+    default_sort_string = """
+points DESC,
+goal_difference DESC,
+goals_scored DESC,
+user_id ASC"""
+    sort_string = default_sort_string
+    statement = text(f"""
+WITH all_matches AS
+(
+    SELECT
+        player1_id
+        , player2_id
+        , winner_id
+        , score_p1
+        , score_p2
+        , status
+    FROM matches
+    WHERE status IS NOT NULL AND status = 'finished'
+)
+, stats_away AS
+(
+    SELECT
+        player2_id
+        AS user_id
+        , count(winner_id) FILTER(WHERE player2_id = winner_id)
+        AS wins
+        , count(winner_id) FILTER(WHERE player1_id = winner_id)
+        AS losses
+        , sum(score_p2)
+        AS goals_scored
+        , sum(score_p1)
+        AS goals_conceded
+    FROM all_matches
+    GROUP BY player2_id
+)
+, stats_home AS
+(
+    SELECT
+        player1_id
+        AS user_id
+        , count(winner_id) FILTER(WHERE player1_id = winner_id)
+        AS wins
+        , count(winner_id) FILTER(WHERE player2_id = winner_id)
+        AS losses
+        , sum(score_p1)
+        AS goals_scored
+        , sum(score_p2)
+        AS goals_conceded
+    FROM all_matches
+    GROUP BY player1_id
+)
+, stats_all AS
+(
+    SELECT * FROM stats_away
+    UNION ALL
+    SELECT * FROM stats_home
+)
+, user_count AS
+(
+    SELECT
+        count(DISTINCT user_id)
+        AS ranked_users
+    FROM stats_all
+)
+, ranked_stats AS
+(
+    SELECT
+        user_id
+        , users.display_name
+        , sum(wins)
+        AS wins
+        , sum(losses)
+        AS losses
+        , sum(goals_scored)
+        AS goals_scored
+        , sum(goals_conceded)
+        AS goals_conceded
+        , (sum(goals_scored) - sum(goals_conceded))
+        AS goal_difference
+        , (3 * SUM(wins))
+        AS points
+    FROM stats_all
+    INNER JOIN users ON users.id = stats_all.user_id
+    GROUP BY user_id, users.display_name
+)
+, ranking_results AS
+(
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY {default_sort_string})
+        AS rank
+        , display_name
+        , points
+        , wins
+        , losses
+        , goals_scored
+        , goals_conceded
+        , goal_difference
+    FROM ranked_stats
+    ORDER BY {sort_string}
+    LIMIT :limit
+    OFFSET (SELECT LEAST(:offset, GREATEST(0, ranked_users - :limit)) FROM user_count)
+)
+SELECT
+    LEAST(:page, ((table user_count) / :limit))
+    AS page
+    , ((table user_count) / :limit)
+    AS last_page
+    , :limit as per_page
+    , (table user_count) as total
+    , COALESCE(jsonb_agg(to_jsonb(ranking_results)), '[]'::jsonb)
+    AS results
+FROM ranking_results
+    """)
+
+    result = await db.execute(
+        statement, {'offset': offset, 'limit': limit, 'page': page}
+    )
+    return result.mappings().one_or_none()
+
+
 async def get_leaderboard(db: AsyncSession, limit: int = 20) -> list[dict]:
     """
     Aggregate finished matches directly in the database to produce a ranked leaderboard.

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -926,10 +926,6 @@ async def award_xp(user_id: int, amount: int, session: AsyncSession):
     )
     result_victories = await victories(user_id, session)
     tournament_amount_xp = 100
-    if amount == tournament_amount_xp:
-        result_victories['tournament_wins'] += 1
-    else:
-        result_victories['regular_wins'] += 1
     await reward_game_achievement_if_should(result_victories, user_id, session)
     xp = result.scalar_one()
     return xp

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -567,7 +567,8 @@ user_id ASC
 WITH all_matches AS
 (
     SELECT
-        player1_id
+        id AS match_id
+        , player1_id
         , player2_id
         , winner_id
         , score_p1
@@ -575,6 +576,7 @@ WITH all_matches AS
         , status
     FROM matches
     WHERE status IS NOT NULL AND status = 'finished'
+    ORDER BY match_id ASC
 )
 , stats_away AS
 (
@@ -614,17 +616,73 @@ WITH all_matches AS
     UNION ALL
     SELECT * FROM stats_home
 )
+, user_distinct AS
+(
+    SELECT
+        DISTINCT user_id
+        AS user_id
+    FROM stats_all
+)
 , user_count AS
 (
     SELECT
-        count(DISTINCT user_id)
-        AS ranked_users
-    FROM stats_all
+        count(*) AS ranked_users
+    FROM user_distinct
+)
+, match_streaks AS
+(
+    SELECT
+        u.user_id
+        , m.match_id
+        , m.winner_id
+
+        , SUM(CASE WHEN m.winner_id = u.user_id
+                   THEN 0
+                   ELSE 1
+              END
+          ) OVER (
+            PARTITION BY u.user_id
+            ORDER BY m.match_id ASC
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        )
+        AS streak_group
+    FROM user_distinct u
+    CROSS JOIN LATERAL (
+        SELECT match_id, winner_id
+        FROM all_matches
+        WHERE player1_id = u.user_id OR player2_id = u.user_id
+        ORDER BY match_id ASC
+    ) m
+)
+, user_win_streaks AS
+(
+    SELECT
+        user_id
+        , streak_group
+        , COUNT(*) FILTER(WHERE user_id = winner_id)
+        AS streak_length
+        , MAX(streak_group) OVER (PARTITION BY user_id)
+        AS last_group
+    FROM match_streaks
+    GROUP BY user_id, streak_group
+)
+, user_win_streak_stats AS
+(
+    SELECT
+        user_id
+        , MAX(streak_length)
+        AS max_streak
+        , MAX(streak_length)
+               FILTER (WHERE streak_group = last_group)
+        AS current_streak
+    FROM user_win_streaks
+    GROUP BY user_id
 )
 , ranked_stats AS
 (
     SELECT
-        user_id
+        users.id
+        AS user_id
         , users.display_name
         , sum(wins)
         AS wins
@@ -640,9 +698,14 @@ WITH all_matches AS
         AS goal_difference
         , (3 * SUM(wins))
         AS points
+        , current_streak
+        , max_streak
     FROM stats_all
-    INNER JOIN users ON users.id = stats_all.user_id
-    GROUP BY user_id, users.display_name
+        INNER JOIN users
+            ON users.id = stats_all.user_id
+        INNER JOIN user_win_streak_stats
+            ON user_win_streak_stats.user_id = users.id
+    GROUP BY users.id, users.display_name, current_streak, max_streak
 )
 , ranking_results AS
 (
@@ -658,10 +721,49 @@ WITH all_matches AS
         , goals_scored
         , goals_conceded
         , goal_difference
+        , current_streak
+        , max_streak
     FROM ranked_stats
+)
+, summary AS
+(
+    SELECT
+        (SELECT
+            jsonb_build_object(
+                'display_name', display_name,
+                'value', max_streak
+            )
+         FROM ranking_results
+         ORDER BY max_streak DESC, {default_sort_string}
+         LIMIT 1)
+        AS max_max_streak
+        , (SELECT
+            jsonb_build_object(
+                'display_name', display_name,
+                'value', points
+            )
+         FROM ranking_results
+         ORDER BY {default_sort_string}
+         LIMIT 1)
+        AS max_points
+        , (SELECT
+            jsonb_build_object(
+                'display_name', display_name,
+                'value', current_streak
+            )
+         FROM ranking_results
+         ORDER BY current_streak DESC, {default_sort_string}
+         LIMIT 1)
+        AS max_current_streak
+)
+, page_ranking_results AS (
+    SELECT * FROM ranking_results
     ORDER BY {sort_string}
     LIMIT :limit
-    OFFSET (SELECT LEAST(:offset, GREATEST(0, ranked_users - :limit)) FROM user_count)
+    OFFSET (SELECT
+               LEAST(:offset,
+                     GREATEST(0, ranked_users - :limit))
+            FROM user_count)
 )
 SELECT
     LEAST(:page, ((table user_count) / :limit))
@@ -670,9 +772,11 @@ SELECT
     AS last_page
     , :limit as per_page
     , (table user_count) as total
-    , COALESCE(jsonb_agg(to_jsonb(ranking_results)), '[]'::jsonb)
+    , COALESCE(jsonb_agg(to_jsonb(page_ranking_results)), '[]'::jsonb)
     AS results
-FROM ranking_results
+    , (SELECT to_jsonb(summary) FROM summary)
+    AS summary
+FROM page_ranking_results
     """)
 
     result = await db.execute(

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -526,7 +526,7 @@ async def get_user_matches(db: AsyncSession, user_id: int) -> list[Match]:
     )
     return list(result.scalars().all())
 
-def leaderboard_order_by_str(sort_assoc: [(str, str)]) -> str:
+def leaderboard_order_by_str(sort_assoc: list[tuple[str, str]] | None) -> str | None:
     if sort_assoc is None:
         return None
     valid_columns = [
@@ -542,7 +542,6 @@ def leaderboard_order_by_str(sort_assoc: [(str, str)]) -> str:
     ]
     order_columns = []
     for (sort_key, order) in sort_assoc:
-        print(sort_key, order)
         norm_order = 'DESC' if order.upper() == 'DESC' else 'ASC'
         norm_key = sort_key.lower() if sort_key.lower() in valid_columns else None
         if norm_key is not None:
@@ -551,7 +550,7 @@ def leaderboard_order_by_str(sort_assoc: [(str, str)]) -> str:
     return result
 
 
-async def get_leaderboard_pagginated(
+async def get_leaderboard_paginated(
         db: AsyncSession, limit: int = 20, page: int = 0, sort_assoc: [(str, str)] = None
 ) -> dict | None:
     offset = page * limit

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -556,7 +556,7 @@ async def get_leaderboard_paginated(
         db: AsyncSession,
         limit: int = 20,
         page: int = 0,
-        sort_assoc: list[tuple[str, str]] = None
+        sort_assoc: list[tuple[str, str]] | None = None
 ) -> dict | None:
     offset = page * limit
     default_sort_string = """
@@ -795,7 +795,10 @@ SELECT
     AS last_page
     , :limit as per_page
     , (table user_count) as total
-    , COALESCE(jsonb_agg(to_jsonb(page_ranking_results)), '[]'::jsonb)
+    , COALESCE(
+        jsonb_agg(to_jsonb(page_ranking_results) ORDER BY {sort_string}),
+        '[]'::jsonb
+    )
     AS results
     , (SELECT to_jsonb(summary) FROM summary)
     AS summary

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -394,6 +394,7 @@ async def finish_match(
     match.score_p2 = score_p2
     match.finished_at = datetime.now(timezone.utc)
     match.status = "finished"
+    await award_xp(winner_id, 10, db)
     await db.commit()
     await db.refresh(match)
     return match
@@ -444,6 +445,7 @@ async def record_tournament_match_result(
         match.status = "finished"
         match.finished_at = datetime.now(timezone.utc)
 
+    await award_xp(winner_id, 100, db)
     current_round = tm.round
     round_result = await db.execute(
         select(TournamentMatch)
@@ -904,8 +906,9 @@ async def get_leaderboard(db: AsyncSession, limit: int = 20) -> list[dict]:
         for rank, row in enumerate(result.mappings().all(), start=1)
     ]
 
-# increment on game end?
+
 async def award_xp(user_id: int, amount: int, session: AsyncSession):
+    """ caller should commit session"""
     statement = text("""
     INSERT INTO user_xp (user_id, xp)
     VALUES (:user_id, :amount)
@@ -915,13 +918,91 @@ async def award_xp(user_id: int, amount: int, session: AsyncSession):
     result = await session.execute(
         statement, {'user_id': user_id, 'amount': amount}
     )
-    result_scalar = result.scalar_one()
-    # await session.commit() # maybe better let caller commit session
-    return result_scalar
+    result_victories = await victories(user_id, session)
+    tournament_amount_xp = 100
+    if amount == tournament_amount_xp:
+        result_victories['tournament_wins'] += 1
+    else:
+        result_victories['regular_wins'] += 1
+    await reward_game_achievement_if_should(result_victories, user_id, session)
+    xp = result.scalar_one()
+    return xp
 
 
-# check on game end?
-async def victories(user_id: int, session: AsyncSession) -> int | None:
+async def reward_game_achievement_if_should(
+        result_victories: dict[str, int], user_id: int, session: AsyncSession):
+    """ caller should commit session"""
+    win_breakpoints = [1, 3, 5, 10, 25, 50, 100, 250, 500, 1000]
+
+    regular_achievement = next((
+        w_break for w_break in win_breakpoints
+        if result_victories['regular_wins'] == w_break
+    ), None)
+
+    if regular_achievement is not None:
+        achievement = {
+            "a_key": f'win{regular_achievement}',
+            "a_name": f'win {regular_achievement} matches',
+            "a_desc": f'You Won {regular_achievement} regular matches',
+            "a_icon": f'({regular_achievement})'
+        }
+        await insert_game_achievement(user_id, achievement, session)
+
+    tournment_achievement = next((
+        w_break for w_break in win_breakpoints
+        if result_victories['tournament_wins'] == w_break
+    ), None)
+
+    if tournment_achievement is not None:
+        achievement = {
+            "a_key": f'twin{tournament_achievement}',
+            "a_name": f'win {tournament_achievement} tournament matches',
+            "a_desc": f'You Won {tournament_achievement} tournament matches',
+            "a_icon": f'_\({tournament_achievement})/_'
+        }
+        await insert_game_achievement(user_id, achievement, session)
+
+
+async def insert_game_achievement(
+        user_id: int, achievement: dict[str,str], session: AsyncSession):
+    """ caller should commit session"""
+    statement = text("""
+WITH
+insert_achievement_if_not_exists AS
+(
+    INSERT INTO achievements (key, name, description, icon)
+        VALUES (:a_key, :a_name, :a_desc, :a_icon)
+    ON CONFLICT (key) DO NOTHING
+    RETURNING id
+)
+, insertion_user_achievement AS
+(
+
+    INSERT INTO user_achievements (user_id, achievement_id)
+        VALUES (:user_id, COALESCE((SELECT id FROM achievements WHERE key = :a_key),
+                                   (table insert_achievement_if_not_exists)))
+    ON CONFLICT (user_id, achievement_id) DO NOTHING
+    RETURNING achievement_id
+)
+, insertion_notification AS
+(
+    INSERT INTO notifications (user_id, type, message)
+        VALUES (:user_id, 'game_achievement', :a_desc)
+)
+SELECT
+    :user_id as user_id
+    ,*
+FROM achievements
+    JOIN insertion_user_achievement on achievement_id = achievements.id
+    """)
+    result = await session.execute(
+        statement, {'user_id': user_id, **achievement}
+    )
+
+    return result.mappings().one_or_none()
+
+
+async def victories(user_id: int, session: AsyncSession) -> dict[str, str]:
     statement = text("""
 WITH matches_results AS
 (
@@ -944,8 +1025,12 @@ WITH matches_results AS
   GROUP BY winner_id
 )
 SELECT
-  (COALESCE(wins, 0) + COALESCE(twins, 0))
+  COALESCE(wins, 0)
   AS wins_total
+  , COALESCE(twins, 0)
+  AS tournament_wins
+  , COALESCE(wins, 0) - COALESCE(twins, 0)
+  AS regular_wins
 FROM matches_results
   FULL OUTER JOIN tournament_matches_results ON winner_id = twinner_id
 LIMIT 1
@@ -953,5 +1038,11 @@ LIMIT 1
     result = await session.execute(
         statement, {'user_id': user_id}
     )
-    result_scalar: int | None = result.scalar_one_or_none()
-    return result_scalar
+
+    ret = result.mappings().one_or_none() or {
+        'wins_total': 0,
+        'regular_wins': 0,
+        'tournament_wins': 0
+    }
+
+    return {**ret}

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -533,6 +533,7 @@ def leaderboard_order_by_str(sort_assoc: [(str, str)]) -> str:
         'rank',
         'display_name',
         'points',
+        'total_games',
         'wins',
         'losses',
         'goals_scored',
@@ -629,6 +630,8 @@ WITH all_matches AS
         AS wins
         , sum(losses)
         AS losses
+        , sum(wins) + sum(losses)
+        AS total_games
         , sum(goals_scored)
         AS goals_scored
         , sum(goals_conceded)
@@ -647,7 +650,9 @@ WITH all_matches AS
         ROW_NUMBER() OVER (ORDER BY {default_sort_string})
         AS rank
         , display_name
+        , user_id
         , points
+        , total_games
         , wins
         , losses
         , goals_scored

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -394,6 +394,7 @@ async def finish_match(
     match.score_p2 = score_p2
     match.finished_at = datetime.now(timezone.utc)
     match.status = "finished"
+    await db.flush()
     await award_xp(winner_id, 10, db)
     await db.commit()
     await db.refresh(match)
@@ -444,7 +445,7 @@ async def record_tournament_match_result(
         match.score_p2 = score_p2
         match.status = "finished"
         match.finished_at = datetime.now(timezone.utc)
-
+    await db.flush()
     await award_xp(winner_id, 100, db)
     current_round = tm.round
     round_result = await db.execute(
@@ -541,6 +542,8 @@ def leaderboard_order_by_str(sort_assoc: list[tuple[str, str]] | None) -> str | 
         'goals_scored',
         'goals_conceded',
         'goal_difference',
+        'max_streak',
+        'current_streak'
     ]
     order_columns = []
     for (sort_key, order) in sort_assoc:
@@ -951,7 +954,7 @@ async def reward_game_achievement_if_should(
         }
         await insert_game_achievement(user_id, achievement, session)
 
-    tournment_achievement = next((
+    tournament_achievement = next((
         w_break for w_break in win_breakpoints
         if result_victories['tournament_wins'] == w_break
     ), None)
@@ -1005,7 +1008,7 @@ FROM achievements
     return result.mappings().one_or_none()
 
 
-async def victories(user_id: int, session: AsyncSession) -> dict[str, str]:
+async def victories(user_id: int, session: AsyncSession) -> dict[str, int]:
     statement = text("""
 WITH matches_results AS
 (

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -959,7 +959,7 @@ async def reward_game_achievement_if_should(
         if result_victories['tournament_wins'] == w_break
     ), None)
 
-    if tournment_achievement is not None:
+    if tournament_achievement is not None:
         achievement = {
             "a_key": f'twin{tournament_achievement}',
             "a_name": f'win {tournament_achievement} tournament matches',

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -526,18 +526,42 @@ async def get_user_matches(db: AsyncSession, user_id: int) -> list[Match]:
     )
     return list(result.scalars().all())
 
+def leaderboard_order_by_str(sort_assoc: [(str, str)]) -> str:
+    if sort_assoc is None:
+        return None
+    valid_columns = [
+        'rank',
+        'display_name',
+        'points',
+        'wins',
+        'losses',
+        'goals_scored',
+        'goals_conceded',
+        'goal_difference',
+    ]
+    order_columns = []
+    for (sort_key, order) in sort_assoc:
+        print(sort_key, order)
+        norm_order = 'DESC' if order.upper() == 'DESC' else 'ASC'
+        norm_key = sort_key.lower() if sort_key.lower() in valid_columns else None
+        if norm_key is not None:
+            order_columns.append(f"{norm_key} {norm_order}")
+    result = ', '.join(order_columns) if len(order_columns) > 0 else None
+    return result
+
 
 async def get_leaderboard_pagginated(
-        db: AsyncSession, limit: int = 20, page: int = 0
+        db: AsyncSession, limit: int = 20, page: int = 0, sort_assoc: [(str, str)] = None
 ) -> dict | None:
-
     offset = page * limit
     default_sort_string = """
 points DESC,
 goal_difference DESC,
 goals_scored DESC,
-user_id ASC"""
-    sort_string = default_sort_string
+user_id ASC
+    """
+    sort_string = leaderboard_order_by_str(sort_assoc)
+    sort_string = sort_string if sort_string is not None else default_sort_string
     statement = text(f"""
 WITH all_matches AS
 (

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -19,6 +19,7 @@ from service.persistence import (
     create_tournament,
     finish_match,
     get_leaderboard,
+    get_leaderboard_pagginated,
     get_match,
     get_tournament_with_participants,
     get_user_matches,
@@ -62,15 +63,23 @@ async def user_stats(user_id: int, session: SessionDependency):
     return await get_user_stats(session, user_id)
 
 
-@router.get("/leaderboard", response_model=list[LeaderboardEntryResponse])
+@router.get("/leaderboard")
 async def leaderboard(
     session: SessionDependency,
-    # Use FastAPI's Query parameters to enforce bounds and document them.  This
-    # replaces manual normalization and will return a 422 response if the
-    # provided limit is out of range.  Defaults to 20, minimum 1, maximum 100.
     limit: int = Query(20, ge=1, le=100),
-) -> list[LeaderboardEntryResponse]:
-    return await get_leaderboard(session, limit)
+    page: int = Query(0, ge=0),
+    order: str = Query('')
+):
+    sort_assoc = []
+    for sort_pair in order.split(','):
+        entry = sort_pair.split(':', maxsplit = 1)
+        if len(entry) == 1:
+            sort_assoc.append((entry[0], 'ASC'))
+        elif len(entry) == 2:
+            sort_assoc.append((entry[0], entry[1]))
+    pagginated_result = \
+        await get_leaderboard_pagginated(session, limit, page, sort_assoc)
+    return pagginated_result
 
 
 @router.get("/matches/history/{user_id}", response_model=list[MatchHistoryItem])

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -75,9 +75,9 @@ async def leaderboard(
     for sort_pair in order.split(','):
         entry = sort_pair.split(':', maxsplit = 1)
         if len(entry) == 1:
-            sort_assoc.append((entry[0], 'ASC'))
+            sort_assoc.append((entry[0].strip(), 'ASC'))
         elif len(entry) == 2:
-            sort_assoc.append((entry[0], entry[1]))
+            sort_assoc.append((entry[0].strip().lower(), entry[1].strip().upper()))
     paginated_result = \
         await get_leaderboard_paginated(session, limit, page, sort_assoc)
     return paginated_result

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -19,7 +19,7 @@ from service.persistence import (
     create_tournament,
     finish_match,
     get_leaderboard,
-    get_leaderboard_pagginated,
+    get_leaderboard_paginated,
     get_match,
     get_tournament_with_participants,
     get_user_matches,
@@ -49,6 +49,7 @@ from service.schemas import (
     TournamentDetailResponse,
     TournamentMatchResponse,
     TournamentParticipantResponse,
+    LeaderboardResponse
 )
 from service.ws.router import manager as ws_manager
 from shared.database import get_db
@@ -63,7 +64,7 @@ async def user_stats(user_id: int, session: SessionDependency):
     return await get_user_stats(session, user_id)
 
 
-@router.get("/leaderboard")
+@router.get("/leaderboard", response_model=LeaderboardResponse)
 async def leaderboard(
     session: SessionDependency,
     limit: int = Query(20, ge=1, le=100),
@@ -77,9 +78,9 @@ async def leaderboard(
             sort_assoc.append((entry[0], 'ASC'))
         elif len(entry) == 2:
             sort_assoc.append((entry[0], entry[1]))
-    pagginated_result = \
-        await get_leaderboard_pagginated(session, limit, page, sort_assoc)
-    return pagginated_result
+    paginated_result = \
+        await get_leaderboard_paginated(session, limit, page, sort_assoc)
+    return paginated_result
 
 
 @router.get("/matches/history/{user_id}", response_model=list[MatchHistoryItem])

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -37,7 +37,6 @@ from service.persistence import (
     withdraw_tournament,
 )
 from service.schemas import (
-    LeaderboardEntryResponse,
     MatchCreateRequest,
     MatchFinishRequest,
     MatchHistoryItem,

--- a/src/backend/game-service/schemas.py
+++ b/src/backend/game-service/schemas.py
@@ -107,3 +107,35 @@ class TournamentDetailResponse(BaseModel):
     created_at: datetime
     participants: list[TournamentParticipantResponse]
     matches: list[TournamentMatchResponse] = []
+
+## Leaderboard
+class PlayerStats(BaseModel):
+    rank: int
+    wins: int
+    losses: int
+    points: int
+    user_id: int
+    max_streak: int
+    total_games: int
+    display_name: str
+    goals_scored: int
+    current_streak: int
+    goals_conceded: int
+    goal_difference: int
+
+class StatEntry(BaseModel):
+    value: int
+    display_name: str
+
+class Summary(BaseModel):
+    max_points: StatEntry
+    max_max_streak: StatEntry
+    max_current_streak: StatEntry
+
+class LeaderboardResponse(BaseModel):
+    page: int
+    last_page: int
+    per_page: int
+    total: int
+    results: list[PlayerStats]
+    summary: Summary

--- a/src/backend/game-service/schemas.py
+++ b/src/backend/game-service/schemas.py
@@ -26,20 +26,6 @@ class StatsResponse(BaseModel):
     goals_scored: int
     goals_conceded: int
 
-
-class LeaderboardEntryResponse(BaseModel):
-    rank: int
-    user_id: int
-    username: str
-    wins: int
-    losses: int
-    total_games: int
-    goals_scored: int
-    goals_conceded: int
-    goal_difference: int
-    points: int
-
-
 class MatchCreateRequest(BaseModel):
     player1_id: int
     player2_id: int

--- a/src/backend/game-service/tests/test_persistence.py
+++ b/src/backend/game-service/tests/test_persistence.py
@@ -41,22 +41,31 @@ async def db():
 
 
 async def _setup_tournament(db, max_participants: int):
+    # Ensure the required users exist (idempotent INSERT) so the test is
+    # self-contained and doesn't depend on pre-seeded database state.
+    # credentials must be inserted first due to the FK on users.credential_id.
+    for uid in range(1, max_participants + 1):
+        await db.execute(
+            text(
+                "INSERT INTO credentials (id, username, password) VALUES (:id, :u, 'x') "
+                "ON CONFLICT (id) DO NOTHING"
+            ),
+            {"id": uid, "u": f"test_user_{uid}"},
+        )
+        await db.execute(
+            text(
+                "INSERT INTO users (id, username, credential_id) VALUES (:id, :u, :cid) "
+                "ON CONFLICT (id) DO NOTHING"
+            ),
+            {"id": uid, "u": f"test_user_{uid}", "cid": uid},
+        )
+    await db.flush()
+
     tournament = await create_tournament(db, name="t", creator_id=1, max_participants=max_participants)
     # Note: create_tournament() already adds creator (uid=1) as a participant
     # So we only need to add remaining participants (2 through max_participants)
-    statement = text("""
-SELECT
-    DISTINCT id
-FROM users
-WHERE
-    NOT id = 1
-ORDER BY id DESC
-LIMIT :limit
-    """)
-    result = await db.execute(statement, {'limit': max_participants - 1})
-    data = result.all()
-    for uid in data:
-        await join_tournament(db, tournament.id, uid[0])
+    for uid in range(2, max_participants + 1):
+        await join_tournament(db, tournament.id, uid)
     _, matches = await start_tournament(db, tournament.id, user_id=1)
     return tournament, matches
 

--- a/src/backend/game-service/tests/test_persistence.py
+++ b/src/backend/game-service/tests/test_persistence.py
@@ -44,8 +44,19 @@ async def _setup_tournament(db, max_participants: int):
     tournament = await create_tournament(db, name="t", creator_id=1, max_participants=max_participants)
     # Note: create_tournament() already adds creator (uid=1) as a participant
     # So we only need to add remaining participants (2 through max_participants)
-    for uid in range(2, max_participants + 1):
-        await join_tournament(db, tournament.id, uid)
+    statement = text("""
+SELECT
+    DISTINCT id
+FROM users
+WHERE
+    NOT id = 1
+ORDER BY id DESC
+LIMIT :limit
+    """)
+    result = await db.execute(statement, {'limit': max_participants - 1})
+    data = result.all()
+    for uid in data:
+        await join_tournament(db, tournament.id, uid[0])
     _, matches = await start_tournament(db, tournament.id, user_id=1)
     return tournament, matches
 

--- a/src/backend/game-service/tests/test_router.py
+++ b/src/backend/game-service/tests/test_router.py
@@ -175,9 +175,10 @@ async def test_get_leaderboard_returns_ranked_rows(client):
     resp = await client.get("/leaderboard")
     assert resp.status_code == 200
     data = resp.json()
+    print(data)
     assert len(data['results']) == 3
     assert data['results'][0]["rank"] == 1
-    assert data['results'][0]["user_id"] == 1
+    assert data['results'][0]["user_id"] == 5001
     assert data['results'][0]["points"] == 3
 
 
@@ -197,8 +198,8 @@ async def test_get_leaderboard_honors_limit_query_param(client):
 
 @pytest.mark.asyncio
 async def test_get_leaderboard_limit_one_page_one(client):
-    for user_id1 in [1, 1, 2, 3, 1, 20, 30, 30, 30]:
-        for user_id2 in [1, 2, 3, 10, 20, 30, 99, 999]:
+    for user_id1 in [5001, 5001, 5002, 5003, 5001, 5020, 5030, 5030, 5030]:
+        for user_id2 in [5001, 5002, 5003, 5010, 5020, 5030, 5099, 5999]:
             if user_id1 == user_id2:
                 continue
             resp_create = await client.post("/matches", json={"player1_id": user_id1, "player2_id": user_id2})
@@ -226,8 +227,8 @@ async def test_get_leaderboard_limit_one_page_one(client):
 
 @pytest.mark.asyncio
 async def test_get_leaderboard_limit_one_page_zero_rank_desc(client):
-    for user_id1 in [1, 1, 2, 3, 1, 20, 30, 30, 30]:
-        for user_id2 in [1, 2, 3, 10, 20, 30, 99, 999]:
+    for user_id1 in [5001, 5001, 5002, 5003, 5001, 5020, 5030, 5030, 5030]:
+        for user_id2 in [5001, 5002, 5003, 5010, 5020, 5030, 5099, 5999]:
             if user_id1 == user_id2:
                 continue
             resp_create = await client.post("/matches", json={"player1_id": user_id1, "player2_id": user_id2})

--- a/src/backend/game-service/tests/test_router.py
+++ b/src/backend/game-service/tests/test_router.py
@@ -175,10 +175,10 @@ async def test_get_leaderboard_returns_ranked_rows(client):
     resp = await client.get("/leaderboard")
     assert resp.status_code == 200
     data = resp.json()
-    assert len(data) == 3
-    assert data[0]["rank"] == 1
-    assert data[0]["user_id"] == 5001
-    assert data[0]["points"] == 3
+    assert len(data['results']) == 3
+    assert data['results'][0]["rank"] == 1
+    assert data['results'][0]["user_id"] == 1
+    assert data['results'][0]["points"] == 3
 
 
 @pytest.mark.asyncio
@@ -190,4 +190,68 @@ async def test_get_leaderboard_honors_limit_query_param(client):
 
     resp = await client.get("/leaderboard?limit=2")
     assert resp.status_code == 200
-    assert len(resp.json()) == 2
+    data = resp.json()
+    assert len(data['results']) == 2
+
+
+
+@pytest.mark.asyncio
+async def test_get_leaderboard_limit_one_page_one(client):
+    for user_id1 in [1, 1, 2, 3, 1, 20, 30, 30, 30]:
+        for user_id2 in [1, 2, 3, 10, 20, 30, 99, 999]:
+            if user_id1 == user_id2:
+                continue
+            resp_create = await client.post("/matches", json={"player1_id": user_id1, "player2_id": user_id2})
+            match_id = resp_create.json()["id"]
+            await client.post(f"/matches/{match_id}/finish", json={"winner_id": user_id1, "score_p1": 1, "score_p2": 0})
+
+    resp = await client.get("/leaderboard?limit=1&page=1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['page'] == 1
+    assert data['per_page'] == 1
+    assert data['last_page'] == 7
+    assert data['total'] == 8
+    results = data['results']
+    assert len(results) == 1
+    assert results[0]['rank'] == 2
+    assert results[0]['max_streak'] == 21
+    assert results[0]['current_streak'] == 21
+    assert results[0]['total_games'] == 27
+    assert results[0]['wins'] == 21
+    assert results[0]['losses'] == 6
+    assert data['summary']['max_max_streak']['value'] == 21
+    assert data['summary']['max_current_streak']['value'] == 21
+    assert data['summary']['max_points']['value'] == 63
+
+@pytest.mark.asyncio
+async def test_get_leaderboard_limit_one_page_zero_rank_desc(client):
+    for user_id1 in [1, 1, 2, 3, 1, 20, 30, 30, 30]:
+        for user_id2 in [1, 2, 3, 10, 20, 30, 99, 999]:
+            if user_id1 == user_id2:
+                continue
+            resp_create = await client.post("/matches", json={"player1_id": user_id1, "player2_id": user_id2})
+            match_id = resp_create.json()["id"]
+            await client.post(f"/matches/{match_id}/finish", json={"winner_id": user_id1, "score_p1": 1, "score_p2": 0})
+
+    resp = await client.get("/leaderboard?limit=1&page=0&order=rank:desc")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data['page'] == 0
+    assert data['per_page'] == 1
+    assert data['last_page'] == 7
+    assert data['total'] == 8
+    results = data['results']
+    assert len(results) == 1
+    assert results[0]['rank'] == 8
+    assert results[0]['wins'] == 0
+    assert results[0]['losses'] == 9
+    assert results[0]['current_streak'] == 0
+    assert results[0]['max_streak'] == 0
+    assert results[0]['goals_scored'] == 0
+    assert results[0]['goals_conceded'] == 9
+    assert results[0]['goal_difference'] == -9
+    assert data['summary']['max_max_streak']['value'] == 21
+    assert data['summary']['max_current_streak']['value'] == 21
+    assert data['summary']['max_points']['value'] == 63

--- a/src/backend/request.http
+++ b/src/backend/request.http
@@ -127,3 +127,6 @@ Authorization: Bearer <access_token>
     "score_p1": 3,
     "score_p2": 5
 }
+
+##
+GET https://localhost:8443/api/game/leaderboard?limit=4&page=1&order=wins:desc,display_name:asc HTTP/1.1

--- a/src/backend/user-service/friends.py
+++ b/src/backend/user-service/friends.py
@@ -131,7 +131,7 @@ async def respond_to_friend_request(
             friendship.status = "accepted"
             await session.flush()
             await reward_friendship_achievement_if_should(
-                request_id, addressee_id, session
+                friendship.requester_id, friendship.addressee_id, session
             )
         else:
             await session.delete(friendship)

--- a/src/backend/user-service/friends.py
+++ b/src/backend/user-service/friends.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from service.models.friendship import Friendship
 from service.models.user import User
-
+from service.persistence import reward_friendship_achievement_if_should
 
 async def get_friends(user_id: int, session: AsyncSession) -> list[User]:
     """Returns User objects for all accepted friends of user_id."""
@@ -130,6 +130,9 @@ async def respond_to_friend_request(
         if action == "accept":
             friendship.status = "accepted"
             await session.flush()
+            await reward_friendship_achievement_if_should(
+                request_id, addressee_id, session
+            )
         else:
             await session.delete(friendship)
     

--- a/src/backend/user-service/persistence.py
+++ b/src/backend/user-service/persistence.py
@@ -1,9 +1,37 @@
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import text
 
+async def reward_friendship_achievement_if_should(
+        requester_id, addressee_id, session
+):
+    friendship_brekpoints = [1, 3, 5, 11, 21, 42, 77, 111, 450, 987]
 
-# check on friend request accepted?
+    requester_friendship_count = \
+        ((await friend_count(requester_id, session)) or 0) + 1
+    addressee_friendship_count = \
+        ((await friend_count(addressee_id, session)) or 0) + 1
+
+    if requester_friendship_count in friendship_brekpoints:
+        achievement = {
+            "a_key": f'friend{requester_friendship_count}',
+            "a_name": f'{requester_friendship_count} mates',
+            "a_desc": f'You Have {requester_friendship_count} mates around here',
+            "a_icon": f'--#{requester_friendship_count}#--'
+        }
+        await insert_user_achievement(
+            requester_id, achievement, session)
+    if addressee_friendship_count in friendship_brekpoints:
+        achievement = {
+            "a_key": f'friend{addressee_friendship_count}',
+            "a_name": f'{addressee_friendship_count} mates',
+            "a_desc": f'You Have {addressee_friendship_count} mates around here',
+            "a_icon": f'--#{addressee_friendship_count}#--'
+        }
+        await insert_user_achievement(
+            addressee_id, achievement, session)
+
 async def friend_count(user_id: int, session: AsyncSession) -> int | None:
+
     statement = text("""
 WITH requested AS
 (
@@ -38,3 +66,42 @@ LIMIT 1
     )
     result_scalar: int | None = result.scalar_one_or_none()
     return result_scalar
+
+
+async def insert_user_achievement(
+        user_id: int, achievement: dict[str,str], session: AsyncSession):
+    """ caller should commit session"""
+
+    statement = text("""
+WITH
+insert_achievement_if_not_exists AS
+(
+    INSERT INTO achievements (key, name, description, icon)
+        VALUES (:a_key, :a_name, :a_desc, :a_icon)
+    ON CONFLICT (key) DO NOTHING
+    RETURNING id
+)
+, insertion_user_achievement AS
+(
+
+    INSERT INTO user_achievements (user_id, achievement_id)
+        VALUES (:user_id, COALESCE((SELECT id FROM achievements WHERE key = :a_key),
+                                   (table insert_achievement_if_not_exists)))
+    ON CONFLICT (user_id, achievement_id) DO NOTHING
+    RETURNING achievement_id
+)
+, insertion_notification AS
+(
+    INSERT INTO notifications (user_id, type, message)
+        VALUES (:user_id, 'user_achievement', :a_desc)
+)
+SELECT
+    :user_id as user_id
+    ,*
+FROM achievements
+    JOIN insertion_user_achievement on achievement_id = achievements.id
+    """)
+    result = await session.execute(
+        statement, {'user_id': user_id, **achievement}
+    )
+    return result.mappings().one_or_none()

--- a/src/backend/user-service/persistence.py
+++ b/src/backend/user-service/persistence.py
@@ -4,12 +4,13 @@ from sqlalchemy import text
 async def reward_friendship_achievement_if_should(
         requester_id, addressee_id, session
 ):
+    print('requester_id', requester_id, 'addressee_id', addressee_id)
     friendship_brekpoints = [1, 3, 5, 11, 21, 42, 77, 111, 450, 987]
 
     requester_friendship_count = \
-        ((await friend_count(requester_id, session)) or 0) + 1
+        ((await friend_count(requester_id, session)) or 0)
     addressee_friendship_count = \
-        ((await friend_count(addressee_id, session)) or 0) + 1
+        ((await friend_count(addressee_id, session)) or 0)
 
     if requester_friendship_count in friendship_brekpoints:
         achievement = {

--- a/src/frontend/src/pages/Leaderboard.jsx
+++ b/src/frontend/src/pages/Leaderboard.jsx
@@ -4,15 +4,30 @@ import NavbarComponent from '../Components/Navbar'
 /**
  * @typedef {Object} LeaderboardEntry
  * @property {number} rank - The rank position
- * @property {number} total_games - Number of wins
+ * @property {number} total_games - Number of total games played
  * @property {number} wins - Number of wins
  * @property {number} losses - Number of losses
  * @property {number} points - Total points
  * @property {number} user_id - User's unique identifier
+ * @property {number} max_streak - Maximum winning streak achieved
  * @property {string} display_name - User's display name
  * @property {number} goals_scored - Total goals scored
+ * @property {number} current_streak - Current winning streak
  * @property {number} goals_conceded - Total goals conceded
  * @property {number} goal_difference - Goal difference (scored - conceded)
+ */
+
+/**
+ * @typedef {Object} StatWithName
+ * @property {number} value - value of stats
+ * @property {string} display_name - Display name of the user who achieved this
+ */
+
+/**
+ * @typedef {Object} LeaderboardSummary
+ * @property {StatWithName} max_points - User with maximum points
+ * @property {StatWithName} max_max_streak - User with maximum streak achievement
+ * @property {StatWithName} max_current_streak - User with maximum current streak
  */
 
 /**
@@ -22,6 +37,7 @@ import NavbarComponent from '../Components/Navbar'
  * @property {number} per_page - Number of items per page
  * @property {number} total - Total number of items across all pages
  * @property {LeaderboardEntry[]} results - Array of leaderboard entries
+ * @property {LeaderboardSummary | null } summary - Summary statistics for the leaderboard
  */
 
 export default function Leaderboard() {
@@ -31,12 +47,18 @@ export default function Leaderboard() {
     last_page: 0,
     per_page: 0,
     total: 0,
-    results: []
+    results: [],
+    summary: {
+      max_max_streak: {value: 0, display_name: 'No Data'},
+      max_current_streak: {value: 0, display_name: 'No Data'},
+      max_points: {value: 0, display_name: 'No Data'}
+    }
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
   const entries = page.results ?? [];
+  const summary = page.summary
   useEffect(() => {
     const controller = new AbortController()
     // Flag to track whether the component has been unmounted.  We set this to
@@ -85,27 +107,6 @@ export default function Leaderboard() {
     }
   }, [])
 
-  const summary = useMemo(() => {
-
-    if (entries.length === 0) {
-      return {
-        highestPoints: 0,
-        longestWins: 0,
-        risingPlayer: 'No data',
-      }
-    }
-    // TODO send this info on page from backend
-    const highestPoints = Math.max(...entries.map((entry) => entry.points))
-    const longestWins = Math.max(...entries.map((entry) => entry.wins))
-    const minRank = Math.min(...entries.map((entry) => entry.rank))
-    const rising = entries.reduce((acc, cur) => acc.rank < cur.rank ? acc : cur, entries[0]);
-    return {
-      highestPoints,
-      longestWins,
-      risingPlayer: rising.display_name || `Player ${rising.user_id}`,
-    }
-  }, [entries])
-
   return (
     <div className="arcade-shell">
       <NavbarComponent />
@@ -133,19 +134,25 @@ export default function Leaderboard() {
               <div className="col-12 col-md-4">
                 <article className="arcade-card h-100 text-center">
                   <p className="arcade-kicker mb-2">Highest points</p>
-                  <div className="arcade-title mb-0" style={{ fontSize: '2.4rem' }}>{summary.highestPoints}</div>
+                  <div className="arcade-title mb-0" style={{ fontSize: '2.4rem' }}>
+                    {summary.max_points.display_name}: {summary.max_points.value}
+                  </div>
                 </article>
               </div>
               <div className="col-12 col-md-4">
                 <article className="arcade-card h-100 text-center">
-                  <p className="arcade-kicker mb-2">Most wins</p>
-                  <div className="arcade-title mb-0" style={{ fontSize: '2.4rem' }}>{summary.longestWins}W</div>
+                  <p className="arcade-kicker mb-2">Largests all time win streak</p>
+                  <div className="arcade-title mb-0" style={{ fontSize: '2.4rem' }}>
+                    {summary.max_max_streak.display_name}: {summary.max_max_streak.value}
+                  </div>
                 </article>
               </div>
               <div className="col-12 col-md-4">
                 <article className="arcade-card h-100 text-center">
-                  <p className="arcade-kicker mb-2">Rising player</p>
-                  <div className="arcade-title mb-0" style={{ fontSize: '2rem' }}>{summary.risingPlayer}</div>
+                  <p className="arcade-kicker mb-2">Largest current win streak</p>
+                  <div className="arcade-title mb-0" style={{ fontSize: '2rem' }}>
+                    {summary.max_current_streak.display_name}: {summary.max_current_streak.value}
+                  </div>
                 </article>
               </div>
             </div>
@@ -171,7 +178,9 @@ export default function Leaderboard() {
                         <th title='Goals For, that is goals scored'>GF</th>
                         <th title='Goals Against, that is goals conceded'>GA</th>
                         <th title='Goals Difference, that is the diference between scored and conceded'>GD</th>
-                        <th>Pts</th>
+                        <th title='Points'>Pts</th>
+                        <th title='Max Win Streak'>MWS</th>
+                        <th title='Current Win Streak'>CWS</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -188,6 +197,8 @@ export default function Leaderboard() {
                             <td>{entry.goals_conceded}</td>
                             <td>{entry.goal_difference}</td>
                             <td>{entry.points}</td>
+                            <td>{entry.max_streak}</td>
+                            <td>{entry.current_streak}</td>
                           </tr>
                         )
                       })}

--- a/src/frontend/src/pages/Leaderboard.jsx
+++ b/src/frontend/src/pages/Leaderboard.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import NavbarComponent from '../Components/Navbar'
 
 /**
@@ -37,7 +37,7 @@ import NavbarComponent from '../Components/Navbar'
  * @property {number} per_page - Number of items per page
  * @property {number} total - Total number of items across all pages
  * @property {LeaderboardEntry[]} results - Array of leaderboard entries
- * @property {LeaderboardSummary | null } summary - Summary statistics for the leaderboard
+ * @property {LeaderboardSummary } summary - Summary statistics for the leaderboard
  */
 
 export default function Leaderboard() {
@@ -141,7 +141,7 @@ export default function Leaderboard() {
               </div>
               <div className="col-12 col-md-4">
                 <article className="arcade-card h-100 text-center">
-                  <p className="arcade-kicker mb-2">Largests all time win streak</p>
+                  <p className="arcade-kicker mb-2">Largest all-time win streak</p>
                   <div className="arcade-title mb-0" style={{ fontSize: '2.4rem' }}>
                     {summary.max_max_streak.display_name}: {summary.max_max_streak.value}
                   </div>
@@ -177,7 +177,7 @@ export default function Leaderboard() {
                         <th title='Games Played'>GP</th>
                         <th title='Goals For, that is goals scored'>GF</th>
                         <th title='Goals Against, that is goals conceded'>GA</th>
-                        <th title='Goals Difference, that is the diference between scored and conceded'>GD</th>
+                        <th title='Goals Difference, that is the difference between scored and conceded'>GD</th>
                         <th title='Points'>Pts</th>
                         <th title='Max Win Streak'>MWS</th>
                         <th title='Current Win Streak'>CWS</th>

--- a/src/frontend/src/pages/Leaderboard.jsx
+++ b/src/frontend/src/pages/Leaderboard.jsx
@@ -1,11 +1,42 @@
 import { useEffect, useMemo, useState } from 'react'
 import NavbarComponent from '../Components/Navbar'
 
-export default function Leaderboard() {
-  const [entries, setEntries] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState('')
+/**
+ * @typedef {Object} LeaderboardEntry
+ * @property {number} rank - The rank position
+ * @property {number} total_games - Number of wins
+ * @property {number} wins - Number of wins
+ * @property {number} losses - Number of losses
+ * @property {number} points - Total points
+ * @property {number} user_id - User's unique identifier
+ * @property {string} display_name - User's display name
+ * @property {number} goals_scored - Total goals scored
+ * @property {number} goals_conceded - Total goals conceded
+ * @property {number} goal_difference - Goal difference (scored - conceded)
+ */
 
+/**
+ * @typedef {Object} LeaderboardResponse
+ * @property {number} page - Current page number
+ * @property {number} last_page - Last page number
+ * @property {number} per_page - Number of items per page
+ * @property {number} total - Total number of items across all pages
+ * @property {LeaderboardEntry[]} results - Array of leaderboard entries
+ */
+
+export default function Leaderboard() {
+  /** @type {[LeaderboardResponse, React.Dispatch<React.SetStateAction<LeaderboardResponse>>]} */
+  const [page, setPage] = useState({
+    page: 0,
+    last_page: 0,
+    per_page: 0,
+    total: 0,
+    results: []
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const entries = page.results ?? [];
   useEffect(() => {
     const controller = new AbortController()
     // Flag to track whether the component has been unmounted.  We set this to
@@ -32,7 +63,7 @@ export default function Leaderboard() {
         const leaderboardData = await leaderboardResp.json()
         // Skip updates if the request was aborted or the effect was cancelled.
         if (controller.signal.aborted || cancelled) return
-        setEntries(leaderboardData)
+        setPage(leaderboardData)
       } catch (requestError) {
         // Ignore abort errors; otherwise report a generic failure.  Avoid
         // updating state if the component has unmounted or the request was aborted.
@@ -55,6 +86,7 @@ export default function Leaderboard() {
   }, [])
 
   const summary = useMemo(() => {
+
     if (entries.length === 0) {
       return {
         highestPoints: 0,
@@ -62,15 +94,15 @@ export default function Leaderboard() {
         risingPlayer: 'No data',
       }
     }
-
-    const highestPoints = entries[0]?.points ?? 0
+    // TODO send this info on page from backend
+    const highestPoints = Math.max(...entries.map((entry) => entry.points))
     const longestWins = Math.max(...entries.map((entry) => entry.wins))
-    const rising = entries.find((entry) => entry.rank > 1) ?? entries[0]
-
+    const minRank = Math.min(...entries.map((entry) => entry.rank))
+    const rising = entries.reduce((acc, cur) => acc.rank < cur.rank ? acc : cur, entries[0]);
     return {
       highestPoints,
       longestWins,
-      risingPlayer: rising.username || `Player ${rising.user_id}`,
+      risingPlayer: rising.display_name || `Player ${rising.user_id}`,
     }
   }, [entries])
 
@@ -131,14 +163,14 @@ export default function Leaderboard() {
                   <table className="leaderboard-table">
                     <thead>
                       <tr>
-                        <th>Rank</th>
-                        <th>Player</th>
-                        <th>W</th>
-                        <th>L</th>
-                        <th>GP</th>
-                        <th>GF</th>
-                        <th>GA</th>
-                        <th>GD</th>
+                        <th title='Player position in ranking'>Rank</th>
+                        <th title='Player display name'>Player</th>
+                        <th title='Wins'>W</th>
+                        <th title='Losses'>L</th>
+                        <th title='Games Played'>GP</th>
+                        <th title='Goals For, that is goals scored'>GF</th>
+                        <th title='Goals Against, that is goals conceded'>GA</th>
+                        <th title='Goals Difference, that is the diference between scored and conceded'>GD</th>
                         <th>Pts</th>
                       </tr>
                     </thead>
@@ -148,7 +180,7 @@ export default function Leaderboard() {
                         return (
                           <tr key={entry.user_id} className={rowClass}>
                             <td>#{entry.rank}</td>
-                            <td>{entry.username || `Player ${entry.user_id}`}</td>
+                            <td>{entry.display_name || `Player ${entry.user_id}`}</td>
                             <td>{entry.wins}</td>
                             <td>{entry.losses}</td>
                             <td>{entry.total_games}</td>


### PR DESCRIPTION
- implements on backend a pagginated leaderboard endpoint featuring:
  - query-string `order` that accepts sort order of results by multiple cols
  - query-string `limit` that defines page size of results
  - query-string `page` that defines the page to be fetched beginning at 0
  - sumary results:
    - most points, display_name and value
    - largest all time win streak, display_name and value
    - largest current win streak, display_name and value
  - page data:
    - total count of entries
    - page fetched
    - last page       

- makes minimal adjustments to frontend to keep leaderboard functional and present new summary data

- TODO 
  - use pagination features on frontend
  - use sorting features on frontend



Closes #236