### PR TITLE
fix: merge alembic heads in user-service

### DIFF
--- a/src/backend/user-service/alembic/versions/20260413_c2c6045ae605_merge_multiple_heads.py
+++ b/src/backend/user-service/alembic/versions/20260413_c2c6045ae605_merge_multiple_heads.py
@@ -1,0 +1,26 @@
+"""merge multiple heads
+
+Revision ID: c2c6045ae605
+Revises: e7dfb79cd018, d8fcaa003ff3
+Create Date: 2026-04-13 04:39:30.810611
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c2c6045ae605'
+down_revision: Union[str, None] = ('e7dfb79cd018', 'd8fcaa003ff3')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Closes #

Resolved conflicting Alembic heads in user-service by adding a merge migration.
Merged revisions:
- e7dfb79cd018
- d8fcaa003ff3

-- This restores a single valid migration head and fixes startup failure in user-service.

Validation
Confirmed:
- alembic heads returns a single head
- user-service starts successfully after migration