### PR TITLE
fix(game): broadcast websocket updates concurrently

### DIFF
--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -26,7 +26,9 @@ from service.schemas import AiGameRequest, AiGameResponse
 from sqlalchemy.exc import SQLAlchemyError
 
 router = APIRouter()
-manager = ConnectionManager()
+# 0.5s send timeout: a slow client must not stall the 30Hz game broadcast loop.
+# Other services (chat, notifications, presence) use the default (no timeout).
+manager = ConnectionManager(send_timeout=0.5)
 
 # Maps game_id (str) → (player1_id, player2_id) for sessions being set up
 _setup_sessions: dict[str, tuple[int, int]] = {}

--- a/src/backend/shared/ws/manager.py
+++ b/src/backend/shared/ws/manager.py
@@ -17,9 +17,14 @@ class ConnectionManager:
     Designed for dependency injection: each service provides its own signal callback.
     """
 
-    def __init__(self, signal_callback: Optional[Callable[[str], Awaitable[None]]] = None) -> None:
+    def __init__(
+        self,
+        signal_callback: Optional[Callable[[str], Awaitable[None]]] = None,
+        send_timeout: float | None = None,
+    ) -> None:
         self._rooms: Dict[str, Set[WebSocket]] = {}
         self._signal_callback = signal_callback
+        self._send_timeout = send_timeout
 
     async def connect(self, room_id: str, websocket: "WebSocket") -> None:
         await websocket.accept()
@@ -31,8 +36,6 @@ class ConnectionManager:
         if not room:
             self._rooms.pop(room_id, None)
 
-    _SEND_TIMEOUT = 0.5  # seconds; slow clients are disconnected rather than blocking the loop
-
     async def _send_to_client(
         self,
         room_id: str,
@@ -40,8 +43,18 @@ class ConnectionManager:
         message: dict,
     ) -> tuple["WebSocket", Exception | None]:
         try:
-            await asyncio.wait_for(websocket.send_json(message), timeout=self._SEND_TIMEOUT)
+            if self._send_timeout is None:
+                await websocket.send_json(message)
+            else:
+                await asyncio.wait_for(
+                    websocket.send_json(message), timeout=self._send_timeout
+                )
             return websocket, None
+        except asyncio.TimeoutError as e:
+            logger.warning(
+                f"Send to client in room {room_id} exceeded {self._send_timeout}s; disconnecting slow client"
+            )
+            return websocket, e
         except Exception as e:
             logger.warning(f"Failed to send to client in room {room_id}: {e}")
             return websocket, e

--- a/src/backend/shared/ws/manager.py
+++ b/src/backend/shared/ws/manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import asyncio
 import logging
 from typing import TYPE_CHECKING, Dict, Set, Optional, Callable, Awaitable

--- a/src/backend/shared/ws/manager.py
+++ b/src/backend/shared/ws/manager.py
@@ -31,6 +31,8 @@ class ConnectionManager:
         if not room:
             self._rooms.pop(room_id, None)
 
+    _SEND_TIMEOUT = 0.5  # seconds; slow clients are disconnected rather than blocking the loop
+
     async def _send_to_client(
         self,
         room_id: str,
@@ -38,7 +40,7 @@ class ConnectionManager:
         message: dict,
     ) -> tuple["WebSocket", Exception | None]:
         try:
-            await websocket.send_json(message)
+            await asyncio.wait_for(websocket.send_json(message), timeout=self._SEND_TIMEOUT)
             return websocket, None
         except Exception as e:
             logger.warning(f"Failed to send to client in room {room_id}: {e}")

--- a/src/backend/shared/ws/manager.py
+++ b/src/backend/shared/ws/manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Dict, Set, Optional, Callable, Awaitable
 
@@ -29,13 +30,29 @@ class ConnectionManager:
         if not room:
             self._rooms.pop(room_id, None)
 
+    async def _send_to_client(
+        self,
+        room_id: str,
+        websocket: "WebSocket",
+        message: dict,
+    ) -> tuple["WebSocket", Exception | None]:
+        try:
+            await websocket.send_json(message)
+            return websocket, None
+        except Exception as e:
+            logger.warning(f"Failed to send to client in room {room_id}: {e}")
+            return websocket, e
+
     async def broadcast(self, room_id: str, message: dict) -> None:
-        for ws in list(self._rooms.get(room_id, set())):
-            try:
-                await ws.send_json(message)
-            except Exception as e:
-                logger.warning(f"Failed to send to client in room {room_id}: {e}")
-                self.disconnect(room_id, ws)
+        sockets = list(self._rooms.get(room_id, set()))
+        if sockets:
+            results = await asyncio.gather(
+                *(self._send_to_client(room_id, ws, message) for ws in sockets)
+            )
+
+            for ws, error in results:
+                if error is not None:
+                    self.disconnect(room_id, ws)
 
         # Signal event registry if callback provided (event-driven delivery)
         if self._signal_callback:

--- a/src/backend/shared/ws/tests/test_manager.py
+++ b/src/backend/shared/ws/tests/test_manager.py
@@ -96,7 +96,7 @@ async def test_broadcast_sends_to_room_clients_concurrently(manager):
 
     broadcast_task = asyncio.create_task(manager.broadcast("room1", {"msg": "hello"}))
     try:
-        await asyncio.wait_for(all_sends_started.wait(), timeout=5)
+        await asyncio.wait_for(all_sends_started.wait(), timeout=1)
     except asyncio.TimeoutError as exc:
         release_sends.set()
         await broadcast_task

--- a/src/backend/shared/ws/tests/test_manager.py
+++ b/src/backend/shared/ws/tests/test_manager.py
@@ -96,7 +96,7 @@ async def test_broadcast_sends_to_room_clients_concurrently(manager):
 
     broadcast_task = asyncio.create_task(manager.broadcast("room1", {"msg": "hello"}))
     try:
-        await asyncio.wait_for(all_sends_started.wait(), timeout=1)
+        await asyncio.wait_for(all_sends_started.wait(), timeout=5)
     except asyncio.TimeoutError as exc:
         release_sends.set()
         await broadcast_task

--- a/src/backend/shared/ws/tests/test_manager.py
+++ b/src/backend/shared/ws/tests/test_manager.py
@@ -1,6 +1,5 @@
 import asyncio
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))  # .../src/backend
@@ -79,20 +78,33 @@ async def test_broadcast_continues_after_failed_send(manager):
 @pytest.mark.asyncio
 async def test_broadcast_sends_to_room_clients_concurrently(manager):
     ws1, ws2 = make_ws(), make_ws()
+    sends_started = 0
+    all_sends_started = asyncio.Event()
+    release_sends = asyncio.Event()
 
-    async def slow_send(_message):
-        await asyncio.sleep(0.05)
+    async def blocked_send(_message):
+        nonlocal sends_started
+        sends_started += 1
+        if sends_started == 2:
+            all_sends_started.set()
+        await release_sends.wait()
 
-    ws1.send_json.side_effect = slow_send
-    ws2.send_json.side_effect = slow_send
+    ws1.send_json.side_effect = blocked_send
+    ws2.send_json.side_effect = blocked_send
     await manager.connect("room1", ws1)
     await manager.connect("room1", ws2)
 
-    started_at = time.perf_counter()
-    await manager.broadcast("room1", {"msg": "hello"})
-    elapsed = time.perf_counter() - started_at
+    broadcast_task = asyncio.create_task(manager.broadcast("room1", {"msg": "hello"}))
+    try:
+        await asyncio.wait_for(all_sends_started.wait(), timeout=1)
+    except asyncio.TimeoutError as exc:
+        release_sends.set()
+        await broadcast_task
+        raise AssertionError("broadcast did not start all sends concurrently") from exc
 
-    assert elapsed < 0.09
+    assert not broadcast_task.done()
+    release_sends.set()
+    await broadcast_task
     ws1.send_json.assert_awaited_once_with({"msg": "hello"})
     ws2.send_json.assert_awaited_once_with({"msg": "hello"})
 

--- a/src/backend/shared/ws/tests/test_manager.py
+++ b/src/backend/shared/ws/tests/test_manager.py
@@ -1,4 +1,6 @@
+import asyncio
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3]))  # .../src/backend
@@ -72,6 +74,27 @@ async def test_broadcast_continues_after_failed_send(manager):
     ws2.send_json.assert_awaited_once_with({"msg": "hello"})
     # Dead socket is evicted — no repeated exceptions on future broadcasts
     assert manager.active_connections("room1") == 1
+
+
+@pytest.mark.asyncio
+async def test_broadcast_sends_to_room_clients_concurrently(manager):
+    ws1, ws2 = make_ws(), make_ws()
+
+    async def slow_send(_message):
+        await asyncio.sleep(0.05)
+
+    ws1.send_json.side_effect = slow_send
+    ws2.send_json.side_effect = slow_send
+    await manager.connect("room1", ws1)
+    await manager.connect("room1", ws2)
+
+    started_at = time.perf_counter()
+    await manager.broadcast("room1", {"msg": "hello"})
+    elapsed = time.perf_counter() - started_at
+
+    assert elapsed < 0.09
+    ws1.send_json.assert_awaited_once_with({"msg": "hello"})
+    ws2.send_json.assert_awaited_once_with({"msg": "hello"})
 
 
 @pytest.mark.asyncio

--- a/src/frontend/src/pages/Tournament.test.jsx
+++ b/src/frontend/src/pages/Tournament.test.jsx
@@ -67,6 +67,11 @@ function renderTournamentPage() {
 }
 
 describe('Tournament page realtime sync', () => {
+  const originalVisibilityState = Object.getOwnPropertyDescriptor(
+    Document.prototype,
+    'visibilityState',
+  )
+
   beforeEach(() => {
     wsHandlers = {}
     mockWsClient.send.mockClear()
@@ -77,6 +82,11 @@ describe('Tournament page realtime sync', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    if (originalVisibilityState) {
+      Object.defineProperty(Document.prototype, 'visibilityState', originalVisibilityState)
+    } else {
+      delete Document.prototype.visibilityState
+    }
   })
 
   it('refreshes tournament data when websocket sends tournament_updated', async () => {
@@ -174,6 +184,12 @@ describe('Tournament page realtime sync', () => {
     const firstTournament = makeTournament([1])
     const secondTournament = makeTournament([1, 2])
     let tournamentReads = 0
+    let visibilityState = 'hidden'
+
+    Object.defineProperty(Document.prototype, 'visibilityState', {
+      configurable: true,
+      get: () => visibilityState,
+    })
 
     apiCall.mockImplementation(async (url) => {
       if (url === '/api/users/auth/me') {
@@ -198,6 +214,7 @@ describe('Tournament page realtime sync', () => {
 
     await screen.findByText(/1 \/ 4 participants/i)
 
+    visibilityState = 'visible'
     await act(async () => {
       document.dispatchEvent(new Event('visibilitychange'))
     })


### PR DESCRIPTION
Closes #
fix(game): broadcast websocket updates concurrently

Description
Esta PR corrige um gargalo no envio de updates via WebSocket durante partidas multiplayer/tournament.

Antes, o ConnectionManager.broadcast enviava mensagens para cada socket de forma sequencial. Se um cliente estivesse lento ou com instabilidade, o envio para os demais também era atrasado, o que podia causar freezes/stutter no jogo, especialmente para jogadores não-host em partidas de torneio.

Agora o broadcast envia as mensagens em paralelo usando asyncio.gather, reduzindo o impacto de clientes lentos sobre a sala. Também foi mantida a remoção de sockets com erro, evitando tentativas repetidas em conexões quebradas.

Testing

Testado manualmente em partida de torneio com dois jogadores.
O comportamento do jogador não-host melhorou significativamente, sem os freezes fortes observados antes.
Adicionado teste unitário para validar que o broadcast envia mensagens de forma concorrente.

Closes #341