### PR TITLE
feat: #228 live games read only ws join

### DIFF
--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -77,6 +77,15 @@ http {
             try_files              $uri =404;
         }
 
+        location /api/games/ {
+            proxy_pass             http://game-service/games/;
+            proxy_http_version     1.1;
+            proxy_set_header       Host $host;
+            proxy_set_header       X-Real-IP $remote_addr;
+            proxy_set_header       X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header       X-Forwarded-Proto $scheme;
+        }
+
         location /api/game/ {
             proxy_pass             http://game-service/;
             proxy_http_version     1.1;

--- a/src/backend/game-service/persistence.py
+++ b/src/backend/game-service/persistence.py
@@ -727,6 +727,42 @@ async def get_user_matches(db: AsyncSession, user_id: int) -> list[Match]:
     )
     return list(result.scalars().all())
 
+
+async def list_live_matches(db: AsyncSession) -> list[dict]:
+    """Return all human-vs-human matches currently in 'ongoing' status,
+    with both players' usernames + display names + avatars.
+
+    AI matches (player_id = 0) are excluded — the AI is not a watchable player.
+    Spectator counts are NOT included here; they are sourced live from the
+    in-memory ConnectionManager by the route handler.
+    """
+    result = await db.execute(
+        text(
+            """
+            SELECT
+                m.id::text                                                      AS match_id,
+                m.player1_id                                                    AS p1_id,
+                u1.username                                                     AS p1_username,
+                COALESCE(NULLIF(TRIM(u1.display_name), ''), u1.username)        AS p1_display_name,
+                u1.avatar_url                                                   AS p1_avatar_url,
+                m.player2_id                                                    AS p2_id,
+                u2.username                                                     AS p2_username,
+                COALESCE(NULLIF(TRIM(u2.display_name), ''), u2.username)        AS p2_display_name,
+                u2.avatar_url                                                   AS p2_avatar_url,
+                m.started_at                                                    AS started_at
+            FROM matches m
+            JOIN users u1 ON u1.id = m.player1_id
+            JOIN users u2 ON u2.id = m.player2_id
+            WHERE m.status = 'ongoing'
+              AND m.player1_id <> 0
+              AND m.player2_id <> 0
+            ORDER BY m.started_at DESC
+            """
+        )
+    )
+    return [dict(row) for row in result.mappings()]
+
+
 def leaderboard_order_by_str(sort_assoc: list[tuple[str, str]] | None) -> str | None:
     valid_columns = [
         'rank',

--- a/src/backend/game-service/router.py
+++ b/src/backend/game-service/router.py
@@ -36,6 +36,7 @@ from service.persistence import (
     get_xp_for_user,
     join_tournament,
     leave_tournament,
+    list_live_matches,
     list_tournaments,
     record_tournament_match_result,
     start_tournament,
@@ -43,6 +44,8 @@ from service.persistence import (
 )
 from service.schemas import (
     AchievementResponse,
+    LiveGamePlayer,
+    LiveGameSummary,
     MatchCreateRequest,
     MatchFinishRequest,
     MatchHistoryItem,
@@ -59,7 +62,9 @@ from service.schemas import (
     XpResponse,
 )
 from service.ws.router import (
+    game_id_for_match,
     manager as ws_manager,
+    spectator_count,
     sync_tournament_ready_timeouts,
 )
 from shared.database import get_db
@@ -480,3 +485,41 @@ async def xp_leaderboard(session: SessionDependency, limit: int = Query(20, ge=1
         {"limit": limit},
     )
     return [dict(row) for row in result.mappings()]
+
+
+@router.get(
+    "/games/live",
+    response_model=list[LiveGameSummary],
+    summary="List currently-active matches (public, no auth)",
+)
+async def list_live_games(session: SessionDependency):
+    rows = await list_live_matches(session)
+    out: list[dict] = []
+    for row in rows:
+        match_id_int = int(row["match_id"])
+        # Only list matches that are actually watchable — i.e., have a live WS
+        # session bound in `_match_id_to_game_id`. A DB row in 'ongoing' status
+        # without a bound session is in a transient state (e.g., between match
+        # creation and the both-players-connected handshake) and isn't yet a
+        # live game.
+        game_id = game_id_for_match(match_id_int)
+        if game_id is None:
+            continue
+        out.append({
+            "game_id": game_id,
+            "player1": {
+                "id": row["p1_id"],
+                "username": row["p1_username"],
+                "display_name": row["p1_display_name"],
+                "avatar_url": row["p1_avatar_url"],
+            },
+            "player2": {
+                "id": row["p2_id"],
+                "username": row["p2_username"],
+                "display_name": row["p2_display_name"],
+                "avatar_url": row["p2_avatar_url"],
+            },
+            "started_at": row["started_at"],
+            "spectator_count": spectator_count(game_id),
+        })
+    return out

--- a/src/backend/game-service/schemas.py
+++ b/src/backend/game-service/schemas.py
@@ -178,3 +178,18 @@ class XpResponse(BaseModel):
     level: int
     xp_in_level: int
     xp_to_next_level: int = 100
+
+
+class LiveGamePlayer(BaseModel):
+    id: int
+    username: str
+    display_name: str
+    avatar_url: str | None = None
+
+
+class LiveGameSummary(BaseModel):
+    game_id: str
+    player1: LiveGamePlayer
+    player2: LiveGamePlayer
+    started_at: datetime
+    spectator_count: int

--- a/src/backend/game-service/tests/test_persistence.py
+++ b/src/backend/game-service/tests/test_persistence.py
@@ -647,3 +647,78 @@ async def test_finish_match_skips_xp_when_ai_is_loser(db):
         text("SELECT xp FROM user_xp WHERE user_id = 0"),
     )).one_or_none()
     assert row_ai is None, "AI sentinel (user_id=0) should never get a user_xp row"
+
+
+# --------------------------------------------------------------------------- #
+# list_live_matches
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_list_live_matches_returns_only_ongoing(db):
+    # Two distinct user pairs to avoid colliding on the same room
+    await _ensure_users(db, 90001, 90002, 90003, 90004)
+    ongoing = await create_match(db, player1_id=90001, player2_id=90002)
+    finished = await create_match(db, player1_id=90003, player2_id=90004)
+    await finish_match(db, finished.id, winner_id=90003, score_p1=10, score_p2=4)
+
+    from persistence import list_live_matches
+    rows = await list_live_matches(db)
+    match_ids = [int(r["match_id"]) for r in rows]
+    assert ongoing.id in match_ids
+    assert finished.id not in match_ids
+
+
+@pytest.mark.asyncio
+async def test_list_live_matches_excludes_ai_games(db):
+    await _ensure_users(db, 90010)
+    # AI sentinel = 0; one side AI → must be excluded
+    ai_match = await create_match(db, player1_id=90010, player2_id=0)
+
+    from persistence import list_live_matches
+    rows = await list_live_matches(db)
+    match_ids = [int(r["match_id"]) for r in rows]
+    assert ai_match.id not in match_ids
+
+
+@pytest.mark.asyncio
+async def test_list_live_matches_projects_player_fields(db):
+    await _ensure_users(db, 90020, 90021)
+    # Set display_name + avatar_url so we can assert projection
+    await db.execute(
+        text("UPDATE users SET display_name='Alice A', avatar_url='/uploads/avatars/90020.png' WHERE id=:i"),
+        {"i": 90020},
+    )
+    await db.execute(
+        text("UPDATE users SET display_name='', avatar_url=NULL WHERE id=:i"),
+        {"i": 90021},
+    )
+    match = await create_match(db, player1_id=90020, player2_id=90021)
+
+    from persistence import list_live_matches
+    rows = await list_live_matches(db)
+    row = next(r for r in rows if int(r["match_id"]) == match.id)
+    assert row["p1_id"] == 90020
+    assert row["p1_username"] == "stats_user_90020"
+    assert row["p1_display_name"] == "Alice A"
+    assert row["p1_avatar_url"] == "/uploads/avatars/90020.png"
+    # Empty display_name falls back to username (COALESCE+NULLIF in SQL)
+    assert row["p2_display_name"] == "stats_user_90021"
+    assert row["p2_avatar_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_live_matches_orders_by_started_at_desc(db):
+    await _ensure_users(db, 90030, 90031, 90032, 90033)
+    older = await create_match(db, player1_id=90030, player2_id=90031)
+    newer = await create_match(db, player1_id=90032, player2_id=90033)
+
+    # Ensure deterministic ordering by adjusting started_at
+    await db.execute(
+        text("UPDATE matches SET started_at = started_at - INTERVAL '1 hour' WHERE id=:i"),
+        {"i": older.id},
+    )
+
+    from persistence import list_live_matches
+    rows = await list_live_matches(db)
+    # Filter to the two we just created
+    relevant = [r for r in rows if int(r["match_id"]) in (older.id, newer.id)]
+    assert [int(r["match_id"]) for r in relevant] == [newer.id, older.id]

--- a/src/backend/game-service/tests/test_router.py
+++ b/src/backend/game-service/tests/test_router.py
@@ -868,3 +868,102 @@ async def test_leaderboard_rank_changes_when_sort_changes(client):
     # Assert ranks are monotonic in each response.
     assert [r["rank"] for r in rows_xp] == sorted([r["rank"] for r in rows_xp])
     assert [r["rank"] for r in rows_wins] == sorted([r["rank"] for r in rows_wins])
+
+
+# --------------------------------------------------------------------------- #
+# GET /games/live (public, no auth)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+async def test_get_live_games_response_is_well_formed_list(client):
+    """Shape-only check: the response is a JSON list and each entry conforms
+    to the LiveGameSummary contract regardless of how many ongoing matches
+    happen to be in the DB at the time."""
+    resp = await client.get("/games/live")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    for entry in body:
+        assert {"game_id", "player1", "player2", "started_at", "spectator_count"} <= entry.keys()
+        assert isinstance(entry["spectator_count"], int)
+
+
+@pytest.mark.asyncio
+async def test_get_live_games_returns_envelope_for_active_match(client):
+    from service.ws.router import _bind_match, _unbind_match
+
+    # Create an ongoing match between two seeded test users
+    create = await client.post(
+        "/matches", json={"player1_id": 5001, "player2_id": 5002}
+    )
+    assert create.status_code == 201, create.text[:200]
+    match_id = create.json()["id"]
+
+    # /games/live only lists matches with a live WS session bound — simulate
+    # one by binding a synthetic game_id to this match_id.
+    test_game_id = f"test-live-{match_id}"
+    _bind_match(test_game_id, match_id)
+
+    try:
+        resp = await client.get("/games/live")
+        assert resp.status_code == 200
+        rows = resp.json()
+        found = next((r for r in rows if r["game_id"] == test_game_id), None)
+        assert found is not None, f"bound match {match_id} should appear in live list"
+        assert found["player1"]["id"] == 5001
+        assert found["player2"]["id"] == 5002
+        assert "started_at" in found
+        # No active spectator WS for this synthetic room → spectator_count == 0
+        assert found["spectator_count"] == 0
+    finally:
+        _unbind_match(test_game_id)
+
+    # Clean up: finish the match so it doesn't leak into subsequent tests
+    finish = await client.post(
+        f"/matches/{match_id}/finish",
+        json={"winner_id": 5001, "score_p1": 7, "score_p2": 0},
+    )
+    assert finish.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_live_games_is_publicly_accessible(client):
+    """No Authorization header → 200, never 401/403."""
+    # The `client` fixture intentionally sets NO auth headers.
+    resp = await client.get("/games/live")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_live_games_skips_matches_without_live_ws_session(client):
+    """A match that exists in the DB as 'ongoing' but has no live WS session
+    bound should NOT appear in /games/live (the endpoint lists watchable
+    games only)."""
+    create = await client.post(
+        "/matches", json={"player1_id": 5003, "player2_id": 5010}
+    )
+    assert create.status_code == 201
+    match_id = create.json()["id"]
+
+    try:
+        resp = await client.get("/games/live")
+        assert resp.status_code == 200
+        rows = resp.json()
+        # The match has no _bind_match call — it should be filtered out.
+        # We don't know the shape of bound game_ids ahead of time, so check
+        # that no entry's underlying match_id matches ours by querying the
+        # reverse map directly.
+        from service.ws.router import _match_ids
+        for entry in rows:
+            mapped_match_id = _match_ids.get(entry["game_id"])
+            assert mapped_match_id != match_id, (
+                f"unbound match {match_id} should not appear in live list, "
+                f"but found entry: {entry}"
+            )
+    finally:
+        # Clean up
+        finish = await client.post(
+            f"/matches/{match_id}/finish",
+            json={"winner_id": 5003, "score_p1": 7, "score_p2": 0},
+        )
+        assert finish.status_code == 200

--- a/src/backend/game-service/tests/test_ws.py
+++ b/src/backend/game-service/tests/test_ws.py
@@ -587,3 +587,98 @@ def test_ws_anonymous_invite_url_probe_does_not_register_or_leak_state(monkeypat
     assert router_module.manager._roles == before_roles, (
         "anonymous probe must not register a role in the manager"
     )
+
+
+@pytest.mark.timeout(5)
+def test_ws_authenticated_third_party_probe_to_invite_url_without_session_closes_4004(monkeypatch):
+    """A logged-in user (valid token, but not one of the invite's players)
+    probing an `invite-X-Y-…` URL when no GameSession exists must ALSO close
+    with 4004 — the spectator gate is on session existence, NOT on whether
+    the caller is anonymous. Otherwise any authenticated user could probe
+    arbitrary invite rooms and inflate spectator counts on phantom games.
+    """
+    import service.ws.router as router_module
+    from datetime import timedelta
+
+    # Issue a valid token for a real third-party user_id (not 99991/99992).
+    from jose import jwt
+    from shared.config.settings import settings
+    third_party_credential_id = 88880
+    third_party_user_id = 88881
+    token = jwt.encode(
+        {"credential_id": third_party_credential_id},
+        settings.JWT_SECRET_KEY,
+        algorithm="HS256",
+    )
+
+    # Stub the credentials lookup so the classifier resolves caller_user_id
+    # without hitting the DB. Patch `text` is intrusive; easier to patch
+    # AsyncSessionLocal so the SELECT yields a row with our user_id.
+    fake_row = (third_party_user_id,)
+    fake_result = MagicMock()
+    fake_result.fetchone = MagicMock(return_value=fake_row)
+
+    class _FakeDb:
+        async def execute(self, *_args, **_kwargs):
+            return fake_result
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *_a):
+            return False
+
+    monkeypatch.setattr(router_module, "AsyncSessionLocal", lambda: _FakeDb())
+
+    # No live session and no setup/waiting state for this game_id.
+    monkeypatch.setattr(
+        router_module.game_manager, "get_session", MagicMock(return_value=None)
+    )
+
+    fake_game_id = "invite-99991-99992-cafef00d"
+    before_roles = dict(router_module.manager._roles)
+    before_waiting = dict(router_module._waiting_room_players)
+
+    client = TestClient(app)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(f"/ws/game/{fake_game_id}?token={token}"):
+            pass
+    # The third-party user is not in (99991, 99992) so they fall to the
+    # spectator branch; the gate then sees no session and closes 4004.
+    assert exc_info.value.code == 4004
+
+    # The probe must not have leaked any state.
+    assert router_module.manager._roles == before_roles, (
+        "authenticated third-party probe must not register a role"
+    )
+    assert router_module._waiting_room_players == before_waiting, (
+        "authenticated third-party probe must not seed _waiting_room_players"
+    )
+
+
+@pytest.mark.timeout(5)
+def test_resolve_room_player_ids_is_read_only_for_invite_urls():
+    """Direct unit test for the read-only contract of _resolve_room_player_ids:
+    parsing an `invite-{p1}-{p2}-…` URL must NOT seed _waiting_room_players.
+    Seeding is the player-path's responsibility (via _ensure_waiting_room_players),
+    NOT the resolver's.
+    """
+    import service.ws.router as router_module
+
+    fake_game_id = "invite-77771-77772-beadbead"
+
+    # Sanity: no pre-existing entry for our test id.
+    before_waiting = dict(router_module._waiting_room_players)
+    assert fake_game_id not in router_module._waiting_room_players
+
+    parsed = router_module._resolve_room_player_ids(fake_game_id)
+
+    # The function still returns the parsed pair so the player path can use it.
+    assert parsed == (77771, 77772), (
+        f"resolver should parse invite-URL into (77771, 77772), got {parsed}"
+    )
+    # …but it must NOT have seeded _waiting_room_players.
+    assert fake_game_id not in router_module._waiting_room_players, (
+        "_resolve_room_player_ids must be read-only — seeding is the player path's job"
+    )
+    assert router_module._waiting_room_players == before_waiting, (
+        "_resolve_room_player_ids must not mutate _waiting_room_players at all"
+    )

--- a/src/backend/game-service/tests/test_ws.py
+++ b/src/backend/game-service/tests/test_ws.py
@@ -549,3 +549,41 @@ def test_ws_spectator_input_closes_with_4003_via_testclient(monkeypatch):
             # Server now receives the input and closes 4003
             ws.receive_text()  # raises WebSocketDisconnect
     assert exc_info.value.code == 4003
+
+
+@pytest.mark.timeout(5)
+def test_ws_anonymous_invite_url_probe_does_not_register_or_leak_state(monkeypatch):
+    """Anonymous client probes an arbitrary invite-{p1}-{p2}-… URL with no
+    live game session. Must close 4004 and must NOT seed _waiting_room_players
+    or register a role in the manager — otherwise an attacker can grow the
+    in-memory maps indefinitely and inflate spectator counts on phantom rooms.
+    """
+    import service.ws.router as router_module
+
+    # Make sure the room is unknown to every state source.
+    monkeypatch.setattr(
+        router_module.game_manager, "get_session", MagicMock(return_value=None)
+    )
+
+    fake_game_id = "invite-99991-99992-deadbeef"
+    # Snapshot pre-state so we can assert no growth.
+    before_waiting = dict(router_module._waiting_room_players)
+    before_setup = dict(router_module._setup_sessions)
+    before_roles = dict(router_module.manager._roles)
+
+    client = TestClient(app)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(f"/ws/game/{fake_game_id}"):
+            pass
+    assert exc_info.value.code == 4004
+
+    # No state should have been seeded by the probe.
+    assert router_module._waiting_room_players == before_waiting, (
+        "anonymous probe must not seed _waiting_room_players"
+    )
+    assert router_module._setup_sessions == before_setup, (
+        "anonymous probe must not seed _setup_sessions"
+    )
+    assert router_module.manager._roles == before_roles, (
+        "anonymous probe must not register a role in the manager"
+    )

--- a/src/backend/game-service/tests/test_ws.py
+++ b/src/backend/game-service/tests/test_ws.py
@@ -36,18 +36,6 @@ def test_ws_healthcheck_access_denied_invalid_token():
 
 
 @pytest.mark.timeout(5)
-def test_ws_game_requires_token_for_non_healthcheck():
-    """Connecting to a non-healthcheck game_id without token should be rejected."""
-    client = TestClient(app)
-    
-    with pytest.raises(WebSocketDisconnect) as exc_info:
-        with client.websocket_connect("/ws/game/some-game-id"):
-            pass
-    
-    assert exc_info.value.code == 4001
-
-
-@pytest.mark.timeout(5)
 def test_ws_games_are_isolated():
     """Multiple healthcheck connections are independent (one-shot nature means no broadcast)."""
     # Healthcheck is one-shot and closes immediately, so broadcast tests are N/A
@@ -367,3 +355,197 @@ async def test_reconnect_cancels_timer_resumes_and_sends_snapshot():
     assert len(broadcasts) == 1
     assert broadcasts[0] == {"type": "opponent_reconnected"}
     assert timer_handled_cancel, "Countdown task should have caught CancelledError"
+
+
+# --------------------------------------------------------------------------- #
+# Spectator classification (Task 7 + 8)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.timeout(5)
+def test_ws_no_token_no_session_closes_4004():
+    """Anonymous client connects to a room with no active session — must be
+    classified as spectator and immediately closed with 4004 (not 4001)."""
+    client = TestClient(app)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/ws/game/spec-test-no-session"):
+            pass
+    assert exc_info.value.code == 4004
+
+
+# --------------------------------------------------------------------------- #
+# Spectator branch — observable behaviours (Task 8)
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(5)
+async def test_spectator_loop_sends_initial_state_and_registers(monkeypatch):
+    """A spectator gets the current game-state snapshot immediately and is
+    registered in the manager with role='spectator'."""
+    import service.ws.router as router_module
+    from service.ws.router import _spectator_loop
+
+    # Stub out manager + session
+    sent_messages: list[dict] = []
+    fake_manager = MagicMock()
+    fake_manager.connect = AsyncMock()
+    fake_manager.disconnect = MagicMock()
+    fake_manager.broadcast = AsyncMock()
+    fake_manager.spectator_count = MagicMock(return_value=1)
+    monkeypatch.setattr(router_module, "manager", fake_manager)
+
+    fake_session = MagicMock()
+    fake_session.get_state_snapshot = MagicMock(return_value=MagicMock(
+        __dataclass_fields__={},  # asdict-friendly
+    ))
+    monkeypatch.setattr(router_module.game_manager, "get_session", MagicMock(return_value=fake_session))
+
+    # Patch asdict so we don't need a real dataclass
+    monkeypatch.setattr(router_module, "asdict", lambda x: {"ball": "stub", "paddles": "stub", "score": "stub"})
+
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.send_json = AsyncMock(side_effect=lambda m: sent_messages.append(m))
+    ws.close = AsyncMock()
+    # Simulate disconnect on the very first receive_text call
+    ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+    await _spectator_loop(ws, "g-1")
+
+    fake_manager.connect.assert_awaited_once_with("g-1", ws, role="spectator")
+    # 1) Snapshot was sent first
+    assert sent_messages[0]["type"] == "state"
+    # 2) Then a spectator_count broadcast was issued (via manager.broadcast)
+    fake_manager.broadcast.assert_any_await("g-1", {"type": "spectator_count", "count": 1})
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(5)
+async def test_spectator_loop_closes_on_inbound_message_with_4003(monkeypatch):
+    """Any inbound message from a spectator triggers close(code=4003)."""
+    import service.ws.router as router_module
+    from service.ws.router import _spectator_loop
+
+    fake_manager = MagicMock()
+    fake_manager.connect = AsyncMock()
+    fake_manager.disconnect = MagicMock()
+    fake_manager.broadcast = AsyncMock()
+    fake_manager.spectator_count = MagicMock(return_value=1)
+    monkeypatch.setattr(router_module, "manager", fake_manager)
+
+    fake_session = MagicMock()
+    fake_session.get_state_snapshot = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(router_module.game_manager, "get_session", MagicMock(return_value=fake_session))
+    monkeypatch.setattr(router_module, "asdict", lambda x: {"ball": "x"})
+
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    ws.receive_text = AsyncMock(return_value='{"type":"input","direction":"up"}')
+
+    await _spectator_loop(ws, "g-2")
+
+    ws.close.assert_awaited()
+    args, kwargs = ws.close.await_args
+    assert kwargs.get("code") == 4003 or (args and args[0] == 4003)
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(5)
+async def test_spectator_loop_broadcasts_count_decrement_on_disconnect(monkeypatch):
+    """When the spectator disconnects, the loop broadcasts the new (lower) count."""
+    import service.ws.router as router_module
+    from service.ws.router import _spectator_loop
+
+    counts = iter([1, 0])  # first call after connect, second after disconnect
+
+    fake_manager = MagicMock()
+    fake_manager.connect = AsyncMock()
+    fake_manager.disconnect = MagicMock()
+    fake_manager.broadcast = AsyncMock()
+    fake_manager.spectator_count = MagicMock(side_effect=lambda *_a, **_kw: next(counts))
+    monkeypatch.setattr(router_module, "manager", fake_manager)
+
+    fake_session = MagicMock()
+    fake_session.get_state_snapshot = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(router_module.game_manager, "get_session", MagicMock(return_value=fake_session))
+    monkeypatch.setattr(router_module, "asdict", lambda x: {"ball": "x"})
+
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+    await _spectator_loop(ws, "g-3")
+
+    # Two count broadcasts: 1 on join, 0 on leave
+    broadcast_calls = [c.args for c in fake_manager.broadcast.await_args_list]
+    counts_broadcast = [args[1]["count"] for args in broadcast_calls if args[1].get("type") == "spectator_count"]
+    assert counts_broadcast == [1, 0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(5)
+async def test_spectator_loop_disconnects_manager_on_exit(monkeypatch):
+    """The loop must always call manager.disconnect on exit, even if the
+    initial state-send raises."""
+    import service.ws.router as router_module
+    from service.ws.router import _spectator_loop
+
+    fake_manager = MagicMock()
+    fake_manager.connect = AsyncMock()
+    fake_manager.disconnect = MagicMock()
+    fake_manager.broadcast = AsyncMock()
+    fake_manager.spectator_count = MagicMock(return_value=0)
+    monkeypatch.setattr(router_module, "manager", fake_manager)
+
+    fake_session = MagicMock()
+    fake_session.get_state_snapshot = MagicMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(router_module.game_manager, "get_session", MagicMock(return_value=fake_session))
+
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect(code=1000))
+
+    await _spectator_loop(ws, "g-4")
+
+    fake_manager.disconnect.assert_called_once_with("g-4", ws)
+    # Even if the snapshot raises, the entry-side count broadcast must still
+    # have been attempted so other clients see the new spectator. Counts a
+    # broadcast as "spectator_count" if the message dict carries that type.
+    spectator_count_broadcasts = [
+        c for c in fake_manager.broadcast.await_args_list
+        if c.args[1].get("type") == "spectator_count"
+    ]
+    assert len(spectator_count_broadcasts) >= 1, (
+        "spectator_count broadcast must fire on entry even when snapshot raises"
+    )
+
+
+@pytest.mark.timeout(5)
+def test_ws_spectator_input_closes_with_4003_via_testclient(monkeypatch):
+    """Integration-level: real TestClient + a stubbed session to verify the
+    classifier reaches the spectator branch and rejects an input message."""
+    import service.ws.router as router_module
+
+    # Inject a fake session for room 'spec-int-1' so the classifier doesn't 4004.
+    fake_session = MagicMock()
+    fake_session.player1_id = 5001
+    fake_session.player2_id = 5002
+    fake_session.get_state_snapshot = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(router_module.game_manager, "get_session", MagicMock(return_value=fake_session))
+    monkeypatch.setattr(router_module, "asdict", lambda x: {"ball": "x"})
+
+    client = TestClient(app)
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect("/ws/game/spec-int-1") as ws:  # no token → spectator
+            # Drain server-pushed pre-input frames: snapshot + spectator_count
+            ws.receive_text()  # initial state snapshot
+            ws.receive_text()  # spectator_count broadcast
+            ws.send_text('{"type":"input","direction":"up"}')
+            # Server now receives the input and closes 4003
+            ws.receive_text()  # raises WebSocketDisconnect
+    assert exc_info.value.code == 4003

--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -84,15 +84,26 @@ def _resolve_room_player_ids(game_id: str) -> tuple[int, int] | None:
 
     Sources, in priority order:
       1. live GameSession (post game-start)
-      2. _ensure_waiting_room_players, which checks _waiting_room_players,
-         _setup_sessions, and as a fallback parses invite-URL room IDs of the
-         form `invite-{p1}-{p2}-{nonce}-…` into _waiting_room_players.
-    Returns None if no source can identify the players.
+      2. _waiting_room_players (already-seeded waiting room)
+      3. _setup_sessions
+      4. _parse_invite_room_players (read-only parse of `invite-{p1}-{p2}-…`)
+
+    READ-ONLY: this function does NOT seed _waiting_room_players. Seeding
+    happens later in the player path via _ensure_waiting_room_players(),
+    only after the caller has been confirmed as a player. That prevents an
+    anonymous probe to an arbitrary `invite-X-Y-…` URL from inflating the
+    in-memory dicts.
     """
     session = game_manager.get_session(game_id)
     if session is not None:
         return (session.player1_id, session.player2_id)
-    return _ensure_waiting_room_players(game_id)
+    waiting = _waiting_room_players.get(game_id)
+    if waiting is not None:
+        return waiting
+    setup = _setup_sessions.get(game_id)
+    if setup is not None:
+        return setup
+    return _parse_invite_room_players(game_id)
 
 
 async def _spectator_loop(websocket: WebSocket, game_id: str) -> None:
@@ -839,8 +850,11 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
     )
 
     if not is_player:
-        # Spectator path. If there is no active room, refuse with 4004.
-        if player_ids is None:
+        # Spectator path: only admit when a live GameSession exists. A match
+        # row without a running session, or an arbitrary invite-URL probe,
+        # is not a watchable game — refuse with 4004 to avoid inflating
+        # spectator_count and growing in-memory maps.
+        if game_manager.get_session(game_id) is None:
             await websocket.close(code=4004, reason="Game not found")
             return
         await _spectator_loop(websocket, game_id)

--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -5,7 +5,7 @@ import time
 from uuid import uuid4
 from dataclasses import asdict
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, HTTPException, Depends
-from jose import jwt
+from jose import jwt, JWTError, ExpiredSignatureError
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,6 +32,9 @@ manager = ConnectionManager()
 _setup_sessions: dict[str, tuple[int, int]] = {}
 # Maps game_id (str) → match_id (int) for database updates
 _match_ids: dict[str, int] = {}
+# Reverse lookup of `_match_ids` — match_id (int) → game_id (str). Maintained
+# alongside every write/delete on `_match_ids`. Public consumers: GET /games/live.
+_match_id_to_game_id: dict[int, str] = {}
 # Maps game_id → player_id who disconnected mid-game (waiting to reconnect or time out)
 _disconnected_players: dict[str, int] = {}
 # Maps game_id → asyncio Task running the disconnect countdown
@@ -50,6 +53,107 @@ _tournament_ready_timeout_tasks: dict[tuple[int, int], asyncio.Task] = {}
 
 READY_TIMEOUT_SECONDS = 90
 _INVITE_ROOM_ID_RE = re.compile(r"^invite-(\d+)-(\d+)-")
+
+
+def _bind_match(game_id: str, match_id: int) -> None:
+    """Set _match_ids[game_id] = match_id and keep the reverse map consistent."""
+    _match_ids[game_id] = match_id
+    _match_id_to_game_id[match_id] = game_id
+
+
+def _unbind_match(game_id: str) -> None:
+    """Remove `game_id` from both `_match_ids` and the reverse map."""
+    match_id = _match_ids.pop(game_id, None)
+    if match_id is not None:
+        _match_id_to_game_id.pop(match_id, None)
+
+
+def game_id_for_match(match_id: int) -> str | None:
+    """Return the live WS `game_id` for the given DB match id, or None if no
+    active session is bound. Used by the public live-games endpoint."""
+    return _match_id_to_game_id.get(match_id)
+
+
+def spectator_count(game_id: str) -> int:
+    """How many spectators are currently connected to `game_id`."""
+    return manager.spectator_count(game_id)
+
+
+def _resolve_room_player_ids(game_id: str) -> tuple[int, int] | None:
+    """Best-effort lookup of (player1_id, player2_id) for an active room.
+
+    Sources, in priority order:
+      1. live GameSession (post game-start)
+      2. _ensure_waiting_room_players, which checks _waiting_room_players,
+         _setup_sessions, and as a fallback parses invite-URL room IDs of the
+         form `invite-{p1}-{p2}-{nonce}-…` into _waiting_room_players.
+    Returns None if no source can identify the players.
+    """
+    session = game_manager.get_session(game_id)
+    if session is not None:
+        return (session.player1_id, session.player2_id)
+    return _ensure_waiting_room_players(game_id)
+
+
+async def _spectator_loop(websocket: WebSocket, game_id: str) -> None:
+    """Read-only WS loop for an anonymous-or-non-player viewer.
+
+    Sequence:
+      1. Register in manager with role='spectator'.
+      2. Send the current game-state snapshot immediately (so the spectator
+         doesn't have to wait for the next tick).
+      3. Broadcast updated spectator_count to ALL connected clients.
+      4. Loop on receive_text(); any inbound message → close 4003.
+      5. On disconnect (any reason): unregister, broadcast new count.
+    """
+    import logging
+    logger = logging.getLogger(__name__)
+
+    await manager.connect(game_id, websocket, role="spectator")
+    try:
+        # Initial state snapshot — best-effort: skip gracefully if the session
+        # is gone or the snapshot itself raises. We deliberately do NOT swallow
+        # send_json failures here; a dead client should propagate to the outer
+        # WebSocketDisconnect handler so the disconnect path is taken cleanly.
+        snapshot_payload: dict | None = None
+        try:
+            session = game_manager.get_session(game_id)
+            if session is not None:
+                snapshot = session.get_state_snapshot()
+                snapshot_payload = {"type": "state", **asdict(snapshot)}
+        except Exception as exc:
+            logger.debug(f"[SPECTATOR] initial snapshot skipped for {game_id}: {exc}")
+
+        if snapshot_payload is not None:
+            await websocket.send_json(snapshot_payload)
+
+        # Announce arrival to everyone in the room.
+        await manager.broadcast(
+            game_id,
+            {"type": "spectator_count", "count": manager.spectator_count(game_id)},
+        )
+
+        # Read-only: any inbound message → reject + close.
+        try:
+            while True:
+                _ = await websocket.receive_text()
+                await websocket.close(
+                    code=4003, reason="Spectators cannot send input"
+                )
+                return
+        except WebSocketDisconnect:
+            # Clean disconnect — fall through to finally.
+            pass
+    finally:
+        manager.disconnect(game_id, websocket)
+        # Best-effort: announce departure (manager may have pruned the room).
+        try:
+            await manager.broadcast(
+                game_id,
+                {"type": "spectator_count", "count": manager.spectator_count(game_id)},
+            )
+        except Exception as exc:
+            logger.debug(f"[SPECTATOR] post-disconnect broadcast skipped for {game_id}: {exc}")
 
 
 async def _broadcast_state(game_id: str, state_snapshot: dict) -> None:
@@ -137,7 +241,7 @@ async def _finalize_regular_match_timeout(
             if match_id is None:
                 created = await create_match(db, player1_id, player2_id)
                 match_id = created.id
-                _match_ids[game_id] = match_id
+                _bind_match(game_id, match_id)
 
             if winner_id is None:
                 await db.execute(
@@ -442,7 +546,7 @@ async def _ensure_game_session(
     _setup_sessions[game_id] = (player1_id, player2_id)
 
     if existing_match_id is not None and game_id not in _match_ids:
-        _match_ids[game_id] = existing_match_id
+        _bind_match(game_id, existing_match_id)
 
     if game_manager.get_session(game_id):
         return
@@ -472,7 +576,7 @@ async def _ensure_game_session(
     try:
         async with AsyncSessionLocal() as db:
             match = await create_match(db, player1_id, player2_id)
-            _match_ids[game_id] = match.id
+            _bind_match(game_id, match.id)
     except SQLAlchemyError:
         pass  # best-effort
 
@@ -539,7 +643,7 @@ async def _on_game_over(game_id: str, winner_id: int, score_p1: int, score_p2: i
         # Clean up memory
         await game_manager.delete_session(game_id)
         _setup_sessions.pop(game_id, None)
-        _match_ids.pop(game_id, None)
+        _unbind_match(game_id)
         _cleanup_waiting_room(game_id)
 
         # Broadcast the game over event authoritatively
@@ -627,7 +731,7 @@ async def start_ai_game(
 
     try:
         match = await create_match(db, player_id, AI_PLAYER_ID)
-        _match_ids[game_id] = match.id
+        _bind_match(game_id, match.id)
     except SQLAlchemyError:
         raise HTTPException(status_code=500, detail="Failed to create match record")
 
@@ -643,7 +747,7 @@ async def start_ai_game(
         )
     except ValueError:
         # game_id collision (astronomically unlikely with uuid4, but guard it)
-        _match_ids.pop(game_id, None)
+        _unbind_match(game_id)
         raise HTTPException(status_code=500, detail="Game session collision")
 
     return AiGameResponse(game_id=game_id)
@@ -695,31 +799,57 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
                 pass
         return
 
-    if not token:
-        await websocket.close(code=4001)
+    # ── Resolve caller (anonymous OK; spec allows anonymous spectators) ──────
+    caller_user_id: int | None = None
+    if token:
+        # Decode the token. JWT failures → anonymous spectator (per spec).
+        credential_id: int | None = None
+        try:
+            payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=["HS256"])
+            credential_id = payload.get("credential_id")
+        except (JWTError, ExpiredSignatureError):
+            credential_id = None
+
+        if credential_id is not None:
+            try:
+                async with AsyncSessionLocal() as db:
+                    result = await db.execute(
+                        text("SELECT id FROM users WHERE credential_id = :cid"),
+                        {"cid": credential_id},
+                    )
+                    row = result.fetchone()
+                    if row:
+                        caller_user_id = row[0]
+            except SQLAlchemyError:
+                # DB hiccup → caller demoted to anonymous spectator. Log it so a
+                # legitimate player going dark on a transient DB failure leaves
+                # a breadcrumb instead of being silently classified as spectator.
+                import logging
+                logging.getLogger(__name__).warning(
+                    "user lookup failed for credential_id=%s; treating ws caller as anonymous",
+                    credential_id, exc_info=True,
+                )
+
+    # ── Classify caller as player vs spectator ──────────────────────────────
+    player_ids = _resolve_room_player_ids(game_id)
+    is_player = (
+        caller_user_id is not None
+        and player_ids is not None
+        and caller_user_id in player_ids
+    )
+
+    if not is_player:
+        # Spectator path. If there is no active room, refuse with 4004.
+        if player_ids is None:
+            await websocket.close(code=4004, reason="Game not found")
+            return
+        await _spectator_loop(websocket, game_id)
         return
 
-    try:
-        payload = jwt.decode(token, settings.JWT_SECRET_KEY, algorithms=["HS256"])
-        credential_id = payload.get("credential_id")
-        if credential_id is None:
-            await websocket.close(code=4001)
-            return
-            
-        # Resolve credential_id -> user.id (Hybrid Pattern Fast Path)
-        async with AsyncSessionLocal() as db:
-            result = await db.execute(
-                text("SELECT id FROM users WHERE credential_id = :cid"),
-                {"cid": credential_id}
-            )
-            row = result.fetchone()
-            if not row:
-                await websocket.close(code=4001)
-                return
-            player_id = row[0]
-    except Exception:
-        await websocket.close(code=4001)
-        return
+    # Player path: continue with the existing handler logic below.
+    # is_player being True means caller_user_id is not None.
+    assert caller_user_id is not None
+    player_id = caller_user_id
 
     # Accept the connection
     await manager.connect(game_id, websocket)
@@ -1051,7 +1181,7 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
             if session is None or session.is_active:
                 await game_manager.delete_session(game_id)
                 _setup_sessions.pop(game_id, None)
-                _match_ids.pop(game_id, None)
+                _unbind_match(game_id)
                 _cleanup_waiting_room(game_id)
 
         else:
@@ -1221,7 +1351,7 @@ async def tournament_websocket(
                         int(tournament_match.player1_id),
                         int(tournament_match.player2_id),
                     )
-                    _match_ids[game_room_id] = int(tournament_match.match_id)
+                    _bind_match(game_room_id, int(tournament_match.match_id))
                     _waiting_room_tournament_context[game_room_id] = (
                         tournament_id,
                         int(tournament_match.match_id),

--- a/src/backend/shared/ws/manager.py
+++ b/src/backend/shared/ws/manager.py
@@ -24,6 +24,12 @@ class ConnectionManager:
     def __init__(self, signal_callback: Optional[Callable[[str], Awaitable[None]]] = None) -> None:
         self._rooms: Dict[str, Set["WebSocket"]] = {}
         self._roles: Dict[Tuple[str, "WebSocket"], str] = {}
+        # Per-room role counters maintained in lockstep with `_rooms` / `_roles` so
+        # `player_count(room)` / `spectator_count(room)` are O(1) instead of
+        # O(total connections). Hot paths: GET /api/games/live (per-row) and
+        # the spectator join/leave broadcast.
+        self._player_counts: Dict[str, int] = {}
+        self._spectator_counts: Dict[str, int] = {}
         self._signal_callback = signal_callback
 
     async def connect(self, room_id: str, websocket: "WebSocket", role: str = "player") -> None:
@@ -32,11 +38,27 @@ class ConnectionManager:
         await websocket.accept()
         self._rooms.setdefault(room_id, set()).add(websocket)
         self._roles[(room_id, websocket)] = role
+        if role == "player":
+            self._player_counts[room_id] = self._player_counts.get(room_id, 0) + 1
+        else:  # spectator (already validated by _VALID_ROLES)
+            self._spectator_counts[room_id] = self._spectator_counts.get(room_id, 0) + 1
 
     def disconnect(self, room_id: str, websocket: "WebSocket") -> None:
+        role = self._roles.pop((room_id, websocket), None)
         room = self._rooms.get(room_id, set())
         room.discard(websocket)
-        self._roles.pop((room_id, websocket), None)
+        if role == "player":
+            new = self._player_counts.get(room_id, 0) - 1
+            if new <= 0:
+                self._player_counts.pop(room_id, None)
+            else:
+                self._player_counts[room_id] = new
+        elif role == "spectator":
+            new = self._spectator_counts.get(room_id, 0) - 1
+            if new <= 0:
+                self._spectator_counts.pop(room_id, None)
+            else:
+                self._spectator_counts[room_id] = new
         if not room:
             self._rooms.pop(room_id, None)
 
@@ -60,13 +82,7 @@ class ConnectionManager:
         return len(self._rooms.get(room_id, set()))
 
     def player_count(self, room_id: str) -> int:
-        return sum(
-            1 for (rid, _ws), role in self._roles.items()
-            if rid == room_id and role == "player"
-        )
+        return self._player_counts.get(room_id, 0)
 
     def spectator_count(self, room_id: str) -> int:
-        return sum(
-            1 for (rid, _ws), role in self._roles.items()
-            if rid == room_id and role == "spectator"
-        )
+        return self._spectator_counts.get(room_id, 0)

--- a/src/backend/shared/ws/manager.py
+++ b/src/backend/shared/ws/manager.py
@@ -1,31 +1,42 @@
 from __future__ import annotations
 import logging
-from typing import TYPE_CHECKING, Dict, Set, Optional, Callable, Awaitable
+from typing import TYPE_CHECKING, Awaitable, Callable, Dict, Optional, Set, Tuple
 
 if TYPE_CHECKING:
     from fastapi import WebSocket
 
 logger = logging.getLogger(__name__)
 
+_VALID_ROLES = ("player", "spectator")
+
 
 class ConnectionManager:
     """Manages WebSocket connections grouped by room/game id.
-    
+
     Optionally signals an event registry when broadcasts occur.
     Designed for dependency injection: each service provides its own signal callback.
+
+    Role tracking is additive — callers that don't pass `role` to `connect()`
+    are recorded as 'player' for backward compatibility. The role map is kept
+    in lockstep with `_rooms`, so disconnects always clean both.
     """
 
     def __init__(self, signal_callback: Optional[Callable[[str], Awaitable[None]]] = None) -> None:
-        self._rooms: Dict[str, Set[WebSocket]] = {}
+        self._rooms: Dict[str, Set["WebSocket"]] = {}
+        self._roles: Dict[Tuple[str, "WebSocket"], str] = {}
         self._signal_callback = signal_callback
 
-    async def connect(self, room_id: str, websocket: "WebSocket") -> None:
+    async def connect(self, room_id: str, websocket: "WebSocket", role: str = "player") -> None:
+        if role not in _VALID_ROLES:
+            raise ValueError(f"role must be one of {_VALID_ROLES}, got {role!r}")
         await websocket.accept()
         self._rooms.setdefault(room_id, set()).add(websocket)
+        self._roles[(room_id, websocket)] = role
 
     def disconnect(self, room_id: str, websocket: "WebSocket") -> None:
         room = self._rooms.get(room_id, set())
         room.discard(websocket)
+        self._roles.pop((room_id, websocket), None)
         if not room:
             self._rooms.pop(room_id, None)
 
@@ -47,3 +58,15 @@ class ConnectionManager:
 
     def active_connections(self, room_id: str) -> int:
         return len(self._rooms.get(room_id, set()))
+
+    def player_count(self, room_id: str) -> int:
+        return sum(
+            1 for (rid, _ws), role in self._roles.items()
+            if rid == room_id and role == "player"
+        )
+
+    def spectator_count(self, room_id: str) -> int:
+        return sum(
+            1 for (rid, _ws), role in self._roles.items()
+            if rid == room_id and role == "spectator"
+        )

--- a/src/backend/shared/ws/tests/test_manager.py
+++ b/src/backend/shared/ws/tests/test_manager.py
@@ -123,11 +123,13 @@ async def test_disconnect_drops_role_entry(manager):
     assert manager.player_count("room1") == 1
     assert manager.spectator_count("room1") == 0
     manager.disconnect("room1", p)
-    # both maps must be empty
+    # All four lockstep maps must be empty after the last disconnect.
     assert manager.player_count("room1") == 0
     assert manager.spectator_count("room1") == 0
     assert manager._rooms == {}
     assert manager._roles == {}
+    assert manager._player_counts == {}
+    assert manager._spectator_counts == {}
 
 
 @pytest.mark.asyncio
@@ -141,3 +143,81 @@ async def test_invalid_role_raises_value_error(manager):
     ws = make_ws()
     with pytest.raises(ValueError):
         await manager.connect("room1", ws, role="cheater")
+
+
+@pytest.mark.asyncio
+async def test_per_room_counts_are_isolated(manager):
+    """Counts on one room must not be affected by connections to another."""
+    p1 = make_ws()
+    p2 = make_ws()
+    s1 = make_ws()
+    await manager.connect("room-a", p1, role="player")
+    await manager.connect("room-b", p2, role="player")
+    await manager.connect("room-a", s1, role="spectator")
+
+    assert manager.player_count("room-a") == 1
+    assert manager.spectator_count("room-a") == 1
+    assert manager.player_count("room-b") == 1
+    assert manager.spectator_count("room-b") == 0
+
+
+@pytest.mark.asyncio
+async def test_double_disconnect_does_not_underflow_counts(manager):
+    """Calling disconnect twice for the same (room, ws) — e.g. handler finally
+    racing with broadcast self-disconnect — must NOT drive the counter
+    negative or below zero."""
+    ws = make_ws()
+    await manager.connect("room1", ws, role="spectator")
+    assert manager.spectator_count("room1") == 1
+
+    manager.disconnect("room1", ws)
+    manager.disconnect("room1", ws)  # idempotent
+
+    assert manager.spectator_count("room1") == 0
+    # The room key should be pruned and the counter dict empty — not stuck
+    # at -1 or with a stale 0-valued entry.
+    assert manager._spectator_counts == {}
+    assert manager._roles == {}
+    assert manager._rooms == {}
+
+
+@pytest.mark.asyncio
+async def test_broadcast_send_failure_decrements_role_counter(manager):
+    """When a send_json failure during broadcast triggers the manager's
+    self-healing disconnect, the per-room role counter must drop with it."""
+    healthy = make_ws()
+    dead = make_ws()
+    dead.send_json = AsyncMock(side_effect=RuntimeError("client gone"))
+    await manager.connect("room1", healthy, role="player")
+    await manager.connect("room1", dead, role="spectator")
+
+    assert manager.player_count("room1") == 1
+    assert manager.spectator_count("room1") == 1
+
+    await manager.broadcast("room1", {"hello": "world"})
+
+    # The dead spectator was auto-disconnected mid-broadcast: its role and
+    # the spectator counter must both have decremented in lockstep.
+    assert manager.spectator_count("room1") == 0
+    assert manager.player_count("room1") == 1  # healthy player untouched
+    assert (("room1", dead)) not in manager._roles
+
+
+@pytest.mark.asyncio
+async def test_counts_track_role_specific_disconnects(manager):
+    """Disconnecting a player must only decrement the player counter; the
+    spectator counter for the same room stays put. Mirrors the reverse for
+    spectator disconnect."""
+    p, s = make_ws(), make_ws()
+    await manager.connect("room1", p, role="player")
+    await manager.connect("room1", s, role="spectator")
+    assert manager.player_count("room1") == 1
+    assert manager.spectator_count("room1") == 1
+
+    manager.disconnect("room1", p)
+    assert manager.player_count("room1") == 0
+    assert manager.spectator_count("room1") == 1  # untouched
+
+    manager.disconnect("room1", s)
+    assert manager.player_count("room1") == 0
+    assert manager.spectator_count("room1") == 0

--- a/src/backend/shared/ws/tests/test_manager.py
+++ b/src/backend/shared/ws/tests/test_manager.py
@@ -82,3 +82,62 @@ async def test_broadcast_does_not_cross_rooms(manager):
     await manager.broadcast("room1", {"msg": "private"})
     ws1.send_json.assert_awaited_once()
     ws2.send_json.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connect_default_role_is_player(manager):
+    ws = make_ws()
+    await manager.connect("room1", ws)
+    assert manager.player_count("room1") == 1
+    assert manager.spectator_count("room1") == 0
+
+
+@pytest.mark.asyncio
+async def test_connect_with_explicit_role_spectator_is_counted(manager):
+    ws = make_ws()
+    await manager.connect("room1", ws, role="spectator")
+    assert manager.player_count("room1") == 0
+    assert manager.spectator_count("room1") == 1
+    # active_connections still counts both
+    assert manager.active_connections("room1") == 1
+
+
+@pytest.mark.asyncio
+async def test_connect_mixed_roles_in_same_room(manager):
+    p1, p2, s1, s2 = make_ws(), make_ws(), make_ws(), make_ws()
+    await manager.connect("room1", p1, role="player")
+    await manager.connect("room1", p2, role="player")
+    await manager.connect("room1", s1, role="spectator")
+    await manager.connect("room1", s2, role="spectator")
+    assert manager.player_count("room1") == 2
+    assert manager.spectator_count("room1") == 2
+    assert manager.active_connections("room1") == 4
+
+
+@pytest.mark.asyncio
+async def test_disconnect_drops_role_entry(manager):
+    p, s = make_ws(), make_ws()
+    await manager.connect("room1", p, role="player")
+    await manager.connect("room1", s, role="spectator")
+    manager.disconnect("room1", s)
+    assert manager.player_count("room1") == 1
+    assert manager.spectator_count("room1") == 0
+    manager.disconnect("room1", p)
+    # both maps must be empty
+    assert manager.player_count("room1") == 0
+    assert manager.spectator_count("room1") == 0
+    assert manager._rooms == {}
+    assert manager._roles == {}
+
+
+@pytest.mark.asyncio
+async def test_unknown_room_counts_zero(manager):
+    assert manager.player_count("nope") == 0
+    assert manager.spectator_count("nope") == 0
+
+
+@pytest.mark.asyncio
+async def test_invalid_role_raises_value_error(manager):
+    ws = make_ws()
+    with pytest.raises(ValueError):
+        await manager.connect("room1", ws, role="cheater")

--- a/tests/api_e2e/test_spectator_flow_e2e.py
+++ b/tests/api_e2e/test_spectator_flow_e2e.py
@@ -1,0 +1,184 @@
+"""End-to-end: anonymous visitor lists live games and joining as spectator
+bumps the spectator_count exposed by GET /api/games/live.
+
+This test runs against the live docker stack (nginx terminating TLS) and uses
+the same `api` fixture/helpers as the rest of tests/api_e2e/.
+
+Notes on what makes a match appear in /api/games/live:
+- The endpoint applies an "Option B" filter: only matches whose game_id is
+  bound in the in-memory `_match_id_to_game_id` reverse map are listed.
+- That binding happens when `_ensure_game_session()` is called with an
+  `existing_match_id` — which the WS handler does once both players have
+  sent `player_ready` and the waiting-room handshake completes.
+- So this test drives the full waiting-room handshake (connect → player_ready
+  → game_start) before connecting the anonymous spectator.
+"""
+import asyncio
+import json
+import secrets
+import ssl
+
+import pytest
+import websockets
+
+from conftest import register_user
+
+
+def _ws_base_from_api(api) -> str:
+    """Convert the api fixture's https://nginx base into wss://nginx."""
+    base = str(api.base_url)
+    if base.startswith("https://"):
+        return "wss://" + base[len("https://"):]
+    if base.startswith("http://"):
+        return "ws://" + base[len("http://"):]
+    return base
+
+
+def _insecure_ssl_ctx() -> ssl.SSLContext:
+    """Self-signed certs in dev → disable verification (matches HTTPX_KWARGS)."""
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    return ctx
+
+
+async def _drain_until(ws, predicate, *, timeout: float = 3.0):
+    """Receive frames until `predicate(frame_dict)` returns True or we time out.
+
+    Returns the matching frame, or None on timeout. Non-matching frames are
+    discarded silently.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            return None
+        try:
+            raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        except asyncio.TimeoutError:
+            return None
+        try:
+            frame = json.loads(raw)
+        except (TypeError, ValueError):
+            continue
+        if predicate(frame):
+            return frame
+
+
+@pytest.mark.asyncio
+async def test_anonymous_visitor_can_list_live_games(api):
+    """No Authorization header -> 200 + a JSON array (possibly empty)."""
+    resp = await api.get("/api/games/live")
+    assert resp.status_code == 200, f"{resp.status_code} {resp.text[:200]}"
+    body = resp.json()
+    assert isinstance(body, list)
+    for entry in body:
+        assert {"game_id", "player1", "player2", "started_at", "spectator_count"} <= entry.keys()
+        assert isinstance(entry["spectator_count"], int)
+        assert entry["spectator_count"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_spectator_count_increments_on_anonymous_ws_join(api):
+    """Two players create a match, both run the waiting-room ready handshake
+    so the in-memory `_match_id_to_game_id` reverse map gets populated, then
+    an anonymous spectator opens a WS to that room.
+
+    GET /api/games/live should then list the match with spectator_count >= 1,
+    and the spectator should be force-closed with code 4003 if it sends an
+    input message.
+    """
+    # 1. Register two players and create an ongoing match between them.
+    alice = await register_user(api)
+    bob = await register_user(api)
+    create = await api.post("/api/game/matches", json={
+        "player1_id": alice["user_id"],
+        "player2_id": bob["user_id"],
+    })
+    assert create.status_code == 201, f"match create: {create.status_code} {create.text[:200]}"
+    match_id = create.json()["id"]
+
+    ssl_ctx = _insecure_ssl_ctx()
+    ws_base = _ws_base_from_api(api)
+    # game_id used on the WS path. Mirror the production frontend's
+    # "invite-{p1}-{p2}-{nonce}" convention so the server's invite-URL parser
+    # can seed _waiting_room_players on the very first connect (post-Task 7
+    # the role classifier runs BEFORE _ensure_waiting_room_players is called
+    # explicitly, so the parser fallback in _resolve_room_player_ids matters).
+    nonce = secrets.token_hex(4)
+    game_id = f"invite-{alice['user_id']}-{bob['user_id']}-{nonce}"
+
+    def player_url(token: str) -> str:
+        return f"{ws_base}/api/game/ws/game/{game_id}?token={token}"
+
+    anon_url = f"{ws_base}/api/game/ws/game/{game_id}"
+
+    # 2. Connect both players, drive the waiting-room ready handshake so the
+    #    server calls _ensure_game_session(..., existing_match_id=match_id),
+    #    which calls _bind_match(game_id, match_id) — required for the match
+    #    to show up in GET /games/live (Option B filter).
+    async with websockets.connect(player_url(alice["token"]), ssl=ssl_ctx) as p1, \
+               websockets.connect(player_url(bob["token"]),   ssl=ssl_ctx) as p2:
+        # Drain the initial waiting_room_status frames.
+        await _drain_until(p1, lambda f: f.get("type") == "waiting_room_status", timeout=2.0)
+        await _drain_until(p2, lambda f: f.get("type") == "waiting_room_status", timeout=2.0)
+
+        # Both players send player_ready (with match_id so it gets bound even
+        # if _setup_sessions wasn't pre-seeded — see _ensure_game_session).
+        ready_p1 = {
+            "type": "player_ready",
+            "user_id": alice["user_id"],
+            "player1_id": alice["user_id"],
+            "player2_id": bob["user_id"],
+            "match_id": match_id,
+        }
+        ready_p2 = {
+            "type": "player_ready",
+            "user_id": bob["user_id"],
+            "player1_id": alice["user_id"],
+            "player2_id": bob["user_id"],
+            "match_id": match_id,
+        }
+        await p1.send(json.dumps(ready_p1))
+        await p2.send(json.dumps(ready_p2))
+
+        # Wait until the server broadcasts game_start on either socket — that
+        # confirms _ensure_game_session has run and the match is bound.
+        gs1 = _drain_until(p1, lambda f: f.get("type") == "game_start", timeout=5.0)
+        gs2 = _drain_until(p2, lambda f: f.get("type") == "game_start", timeout=5.0)
+        game_start_frames = await asyncio.gather(gs1, gs2)
+        assert any(f is not None for f in game_start_frames), (
+            f"never received game_start on either socket; frames={game_start_frames}"
+        )
+
+        # 3. Anonymous spectator joins the same room (no token).
+        async with websockets.connect(anon_url, ssl=ssl_ctx) as spec:
+            # Allow the count broadcast to round-trip and the manager to
+            # register the spectator role before we hit the HTTP endpoint.
+            await asyncio.sleep(0.5)
+
+            # 4. GET /api/games/live → match listed with spectator_count >= 1.
+            resp = await api.get("/api/games/live")
+            assert resp.status_code == 200, resp.text[:200]
+            entries = resp.json()
+            ours = next((e for e in entries if e["game_id"] == game_id), None)
+            assert ours is not None, (
+                f"game_id {game_id} (match {match_id}) not in /games/live. "
+                f"Entries: {[e['game_id'] for e in entries]}"
+            )
+            assert ours["spectator_count"] >= 1, (
+                f"expected spectator_count >= 1, got {ours['spectator_count']}"
+            )
+            assert ours["player1"]["id"] == alice["user_id"]
+            assert ours["player2"]["id"] == bob["user_id"]
+
+            # 5. Spectator misuse: any input message → server closes with 4003.
+            await spec.send(json.dumps({"type": "input", "direction": "up"}))
+            with pytest.raises(websockets.exceptions.ConnectionClosed) as exc_info:
+                # Drain any frames the server may have sent before closing
+                # (e.g. spectator_count); eventually recv() raises.
+                while True:
+                    await asyncio.wait_for(spec.recv(), timeout=2.0)
+            assert exc_info.value.code == 4003, (
+                f"expected close code 4003, got {exc_info.value.code}"
+            )

--- a/tests/api_e2e/test_spectator_flow_e2e.py
+++ b/tests/api_e2e/test_spectator_flow_e2e.py
@@ -65,6 +65,27 @@ async def _drain_until(ws, predicate, *, timeout: float = 3.0):
             return frame
 
 
+async def _poll_for_spectator_count(api, game_id, expected_min: int, *, timeout: float = 3.0, interval: float = 0.05):
+    """Poll GET /api/games/live until a row matching `game_id` has
+    `spectator_count >= expected_min`, or the deadline expires.
+
+    Returns the matching entry on success, None on timeout. Replaces fixed
+    `asyncio.sleep` waits so the test passes on slow CI without artificial delay.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    last_entry = None
+    while asyncio.get_event_loop().time() < deadline:
+        resp = await api.get("/api/games/live")
+        if resp.status_code == 200:
+            entry = next((e for e in resp.json() if e["game_id"] == game_id), None)
+            if entry is not None:
+                last_entry = entry
+                if entry["spectator_count"] >= expected_min:
+                    return entry
+        await asyncio.sleep(interval)
+    return last_entry
+
+
 @pytest.mark.asyncio
 async def test_anonymous_visitor_can_list_live_games(api):
     """No Authorization header -> 200 + a JSON array (possibly empty)."""
@@ -153,21 +174,14 @@ async def test_spectator_count_increments_on_anonymous_ws_join(api):
 
         # 3. Anonymous spectator joins the same room (no token).
         async with websockets.connect(anon_url, ssl=ssl_ctx) as spec:
-            # Allow the count broadcast to round-trip and the manager to
-            # register the spectator role before we hit the HTTP endpoint.
-            await asyncio.sleep(0.5)
-
-            # 4. GET /api/games/live → match listed with spectator_count >= 1.
-            resp = await api.get("/api/games/live")
-            assert resp.status_code == 200, resp.text[:200]
-            entries = resp.json()
-            ours = next((e for e in entries if e["game_id"] == game_id), None)
+            # Poll /api/games/live until the spectator role is registered and
+            # the HTTP endpoint reflects spectator_count >= 1. Deterministic
+            # alternative to a fixed sleep — fails only when the behaviour
+            # is actually broken.
+            ours = await _poll_for_spectator_count(api, game_id, expected_min=1, timeout=3.0)
             assert ours is not None, (
-                f"game_id {game_id} (match {match_id}) not in /games/live. "
-                f"Entries: {[e['game_id'] for e in entries]}"
-            )
-            assert ours["spectator_count"] >= 1, (
-                f"expected spectator_count >= 1, got {ours['spectator_count']}"
+                f"game_id {game_id} (match {match_id}) never reached "
+                f"spectator_count >= 1 within poll window"
             )
             assert ours["player1"]["id"] == alice["user_id"]
             assert ours["player2"]["id"] == bob["user_id"]


### PR DESCRIPTION
Closes #228 

# Spectator Mode — Frontend (Issue #229) Design Spec

**Issue:** [#229 [FRONT] Spectator 2 — Live games list page + watch view](https://github.com/biralavor/42_transcendence/issues/229)
**Parent issue:** [#227 [MODULE] Spectator Mode](https://github.com/biralavor/42_transcendence/issues/227)
**Blocked by:** [#228 [BACK] Spectator 1](https://github.com/biralavor/42_transcendence/issues/228) — backend endpoints must exist first.
**Date:** 2026-04-27
**Companion to:** `2026-04-27-spectator-mode-228-backend-design.md`

---

## Goal

Three frontend additions on top of the issue #228 backend:

1. **`/games/live` page** — public list of currently-active games, polling `GET /api/games/live` every 10s, with a "Watch" button per game.
2. **Watch view** — when the existing `GamePage` is loaded with `?spectate=true`, connect to the WS as a spectator (no input bindings, "Watching" banner, spectator count overlay).
3. **Home page "Live Match" pill** — the existing static arena-pill on Home becomes dynamic: links to the most-spectated active game; auto-refreshes every 10s; hides when there are no live games.

---

## Constraints — what already exists, what's blocking, what's required

### What's already in place
| Capability | Location | Notes |
|------------|----------|-------|
| Game canvas | `Components/PongCanvasMultiplayer.jsx` | Server-state-driven canvas; can render without local input bindings |
| Game page route | `pages/GamePage.jsx` + `App.jsx` (route `/game/:roomId`) | Where the watch view will mount |
| Home arena-pill (static) | `pages/Home.jsx:71` `<span className="arena-pill">Live match</span>` | Currently hardcoded text + score; needs to become a clickable Link |
| Public-route pattern | `App.jsx` routes that aren't wrapped in `PrivateRoute` | New `/games/live` route uses this — visible to logged-out visitors |
| WS client | `utils/wsClient.js` | Reusable for spectator connection |
| Polling pattern | Already used by notification context, leaderboard | Use `setInterval` with cleanup on unmount |
| `apiCall(path, { skipRefreshOn401: true })` | `utils/apiClient.js` | Use for `/api/games/live` since logged-out visitors must not get redirected to login |

### What's blocking
- **Issue #228** — the new endpoints don't exist yet. This frontend work cannot start until the backend lands.

### Project-level constraints (from `CLAUDE.md` + 42 subject)
- SPA navigation — `/games/live` must work via React Router; no full-page reload
- Browser back/forward — going from `/games/live` → `/game/{id}?spectate=true` → back must restore the list
- Latest Chrome must work — Issue #238 added cross-browser awareness; same applies here
- Game robustness — spectator WS disconnects gracefully (lag, network drop) without crashing the page
- TLS — both `https://` for the REST poll and `wss://` for the WS connection (already standard in the app)

### Authentication / public-route considerations
- `/games/live` page is **public** — accessible without login. The Navbar still renders (with login/register buttons for anonymous visitors).
- Watch view inherits `/game/:roomId` route, which is currently wrapped in `PrivateRoute` (assumed; needs verification). For spectators, this route MUST be reachable without auth when `?spectate=true` is present. Two options:
  - **(A)** Move the route out of `PrivateRoute` and gate the player-mode behavior internally
  - **(B)** Add a sibling public route `/spectate/:roomId` that renders `<GamePage spectate />`
  - **Recommendation: (A)** — single route, single canvas component, mode controlled by query param. Simpler routing, fewer files.

---

## Architecture

```
                                    ┌──────────────────────┐
GET /api/games/live  ───── poll ───→│  /games/live page    │
(every 10s)                          │  - card per game     │
                                     │  - "Watch" button →  │
                                     └──────────┬───────────┘
                                                │ navigate
                                                ▼
                                     ┌──────────────────────┐
                                     │ /game/{id}?spectate=true│
                                     │  GamePage             │
                                     │   - skip input bindings │
                                     │   - "Watching" banner   │
                                     │   - spectator_count UI│
                                     │   - WS connection (no token if anonymous)│
                                     └──────────────────────┘


                                     ┌──────────────────────┐
GET /api/games/live  ───── poll ───→│  Home arena-pill     │
(every 10s)                          │  pick top-spectated  │
                                     │  pill → /game/{id}?spectate=true │
                                     └──────────────────────┘
```

---

## Component / page additions

### New page: `pages/GamesLive.jsx` + `pages/GamesLive.css`

**State:**
- `games: LiveGameSummary[]` — from API (typedef matches backend `LiveGameSummary` from spec #228)
- `loading: boolean`
- `error: string | null`

**Effects:**
- On mount: `fetch('/api/games/live')` (use plain `fetch` since this is a public route — no auth header needed)
- `setInterval(refresh, 10000)` — re-poll every 10s
- Cleanup interval on unmount

**UI:**
- Header: "Live Games"
- Empty state: "No games being played right now."
- Each game card:
  - Avatars (left + right)
  - Usernames (with display_name fallback)
  - Elapsed time (computed from `started_at`)
  - Spectator count badge ("3 watching")
  - "Watch" button → `<Link to={`/game/${game_id}?spectate=true`}>`

**Routing:**
- New route in `App.jsx`: `<Route path="/games/live" element={<GamesLive />} />`
- **Outside** `PrivateRoute` — public.
- Add a "Live games" link in `Navbar.jsx` (visible to all, logged in or not).

### Modified: `pages/GamePage.jsx`

Detect `?spectate=true` from `useSearchParams()`:

```jsx
const [searchParams] = useSearchParams()
const isSpectator = searchParams.get('spectate') === 'true'
```

Branch behavior:
- **WS connect:** include token only if user is logged in; else open anonymously. Backend (#228) handles classification.
- **Input handlers:** if `isSpectator`, skip the `useEffect` that wires keyboard handlers to the canvas (or pass `disabled={isSpectator}` to `PongCanvasMultiplayer`).
- **UI:**
  - Banner above canvas: "Watching as spectator" (visible only when `isSpectator`)
  - Spectator-count badge in the header (shows latest `spectator_count` WS frames)
  - Hide the player-side actions (no "Ready", "Forfeit" etc.)

State additions:
- `spectatorCount: number` — updated on each `{"type":"spectator_count", "count":N}` WS frame

WS message handler (extension):
```jsx
ws.onmessage = (event) => {
  const frame = JSON.parse(event.data)
  if (frame.type === 'state') { /* existing */ }
  else if (frame.type === 'spectator_count') {
    setSpectatorCount(frame.count)
  }
}
```

### Modified: `pages/Home.jsx` — dynamic "Live Match" arena-pill

Replace the static `<span className="arena-pill">Live match</span>` with a polled, dynamic pill:

```jsx
const [topGame, setTopGame] = useState(null)

useEffect(() => {
  let cancelled = false
  const tick = async () => {
    try {
      const r = await fetch('/api/games/live')
      const games = r.ok ? await r.json() : []
      if (cancelled) return
      // pick the game with the highest spectator_count; tie-break by started_at (newest)
      const top = games.reduce(
        (best, g) => (best == null ||
          g.spectator_count > best.spectator_count ||
          (g.spectator_count === best.spectator_count &&
            new Date(g.started_at) > new Date(best.started_at)))
          ? g : best,
        null,
      )
      setTopGame(top)
    } catch { /* ignore */ }
  }
  tick()
  const id = setInterval(tick, 10_000)
  return () => { cancelled = true; clearInterval(id) }
}, [])

// in JSX, replace the static pill:
{topGame ? (
  <Link to={`/game/${topGame.game_id}?spectate=true`} className="arena-pill arena-pill--live">
    Live Match · {topGame.player1.username} vs {topGame.player2.username} · 👁 {topGame.spectator_count}
  </Link>
) : null}
```

When `topGame` is null (empty response), the pill is hidden — and the rest of the arena card (the static preview) stays.

### Routing changes (`App.jsx`)
- Add: `<Route path="/games/live" element={<GamesLive />} />` (public)
- Verify: `<Route path="/game/:roomId" element={<GamePage />} />` is **not** wrapped in `PrivateRoute`. If it currently is, move it out and let `GamePage` itself redirect to `/login` only when `!isSpectator && !auth.access_token`.

---

## CSS additions

### `pages/GamesLive.css`
- `.live-games-grid` — responsive card grid (3 columns on desktop, 1 on mobile, similar to BadgeGrid pattern)
- `.live-game-card` — flex column with avatars + names + spectator badge + Watch button
- `.live-game-elapsed` — small monospace time ("3:42")
- `.live-game-empty` — centered placeholder

### `pages/GamePage.css` (additions)
- `.spectator-banner` — top of canvas, accent border, "Watching" text
- `.spectator-count-badge` — top-right corner of canvas, shows "👁 N"

### `pages/Home.css` (or wherever arena-pill is defined)
- `.arena-pill--live` — inherits `.arena-pill` styling but adds a pulsing accent (e.g., `animation: live-pulse 2s infinite`) to draw attention

---

## Testing strategy

### Frontend tests

**New: `pages/GamesLive.test.jsx`**
- Renders empty state when API returns `[]`
- Renders one card per game in API response
- "Watch" link href is `/game/{id}?spectate=true`
- Clicking "Watch" navigates (assert via `MemoryRouter`'s navigation tracking)
- Polls every 10s — use `vi.useFakeTimers()` to advance and verify second fetch
- Cleans up interval on unmount

**Extended: `pages/GamePage.test.jsx`**
- `?spectate=true` shows "Watching" banner
- `?spectate=true` does NOT bind keyboard handlers (assert by firing `keydown` and verifying no input is sent on the WS mock)
- WS frame `{"type":"spectator_count","count":5}` updates the on-screen badge
- Without `?spectate=true`, behavior is unchanged (regression guard)

**Extended: `pages/Home.test.jsx`**
- Static pill is replaced with the dynamic `<Link>` when a top game exists
- Pill is hidden when API returns empty
- Pill href reflects the most-spectated game (assert with mock data: g1 has 5 spectators, g2 has 2 → href is g1's)
- Polls every 10s, updates pill when API mock advances to a new top game

### API E2E test addition (paired with backend #228 work)

`tests/api_e2e/test_spectator_flow_e2e.py` already contains anonymous-list + spectator-count tests at the API level. No additional E2E test needed for the frontend in v1 — Playwright would be the right tool for the full browser flow but is out of scope (see existing E2E proposal doc).

---

## Out of scope (defer)

- **Spectator chat** — no per-game chat for spectators; out of scope per the parent issue
- **Spectator reactions** (cheering emoji, etc.) — nice-to-have, out of scope
- **WebSocket-based live-update of `/games/live` list** — list polls every 10s; that's enough per the issue spec
- **Persistent spectator stats** ("you watched X games") — not in the parent issue
- **Notifying followed friends when they start a game** — separate feature

---

## File map

| File | Action | Purpose |
|------|--------|---------|
| `src/frontend/src/pages/GamesLive.jsx` | Create | New public page listing live games |
| `src/frontend/src/pages/GamesLive.css` | Create | Styles for the cards / grid |
| `src/frontend/src/pages/GamesLive.test.jsx` | Create | 5-7 tests for the list page |
| `src/frontend/src/pages/GamePage.jsx` | Modify | Detect `?spectate=true`, skip input bindings, banner, count badge |
| `src/frontend/src/pages/GamePage.css` | Modify | Spectator banner + count badge styles |
| `src/frontend/src/pages/GamePage.test.jsx` | Modify | 3-4 new tests for spectator branch |
| `src/frontend/src/pages/Home.jsx` | Modify | Dynamic Live Match pill with 10s polling |
| `src/frontend/src/pages/Home.test.jsx` | Modify (or create — check) | 3-4 new tests for the dynamic pill |
| `src/frontend/src/App.jsx` | Modify | Add `/games/live` public route |
| `src/frontend/src/Components/Navbar.jsx` | Modify | Add "Live games" link, visible to all |

---

## Estimated effort

~1.5-2 sprints (4-6 days):
- New `GamesLive` page + tests: 1.5 days
- GamePage spectator-mode changes + tests: 1.5 days
- Home dynamic pill + tests: 1 day
- Routing + Navbar update: 0.5 day
- Cross-browser smoke testing: 0.5 day
- PR review iteration: 0.5 day

---

## Dependencies graph

```
#228 (backend) ──── must land first ───→ #229 (frontend)
                                              │
                                              └─→ closes #227 module
```

The frontend cannot be developed in isolation because the WS spectator path and the public list endpoint don't exist yet. **Recommended: implement #228, deploy, smoke-test it, then start #229.**

