### PR TITLE
226 front advanced search 4   match history filter controls

### DIFF
--- a/src/frontend/src/pages/Profile.css
+++ b/src/frontend/src/pages/Profile.css
@@ -285,6 +285,60 @@
   padding: 0.2rem 0.45rem;
 }
 
+.history-clear-button {
+  min-height: 2rem;
+  border: 1px solid rgba(251, 192, 45, 0.45);
+  border-radius: 0.35rem;
+  background: rgba(251, 192, 45, 0.08);
+  color: var(--primary);
+  font-family: 'VT323', monospace;
+  font-size: 1.15rem;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.7rem;
+  cursor: pointer;
+}
+
+.history-clear-button:hover {
+  background: rgba(251, 192, 45, 0.16);
+}
+
+.history-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.history-page-button {
+  min-height: 2rem;
+  border: 1px solid rgba(251, 192, 45, 0.45);
+  border-radius: 0.35rem;
+  background: rgba(251, 192, 45, 0.08);
+  color: var(--primary);
+  font-family: 'VT323', monospace;
+  font-size: 1.15rem;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.7rem;
+  cursor: pointer;
+}
+
+.history-page-button:hover:not(:disabled) {
+  background: rgba(251, 192, 45, 0.16);
+}
+
+.history-page-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.history-page-summary {
+  color: rgba(245, 245, 242, 0.85);
+  font-family: 'VT323', monospace;
+  font-size: 1.15rem;
+  letter-spacing: 0.05em;
+}
+
 .history-table {
   width: 100%;
   border: 1px solid rgba(251, 192, 45, 0.3);

--- a/src/frontend/src/pages/Profile.css
+++ b/src/frontend/src/pages/Profile.css
@@ -265,6 +265,26 @@
   accent-color: var(--primary);
 }
 
+.history-filter-date input {
+  min-height: 2rem;
+  border: 1px solid rgba(251, 192, 45, 0.35);
+  border-radius: 0.35rem;
+  background: rgba(10, 10, 10, 0.45);
+  color: rgba(245, 245, 242, 0.92);
+  font: inherit;
+  padding: 0.2rem 0.45rem;
+}
+
+.history-filter-select select {
+  min-height: 2rem;
+  border: 1px solid rgba(251, 192, 45, 0.35);
+  border-radius: 0.35rem;
+  background: rgba(10, 10, 10, 0.45);
+  color: rgba(245, 245, 242, 0.92);
+  font: inherit;
+  padding: 0.2rem 0.45rem;
+}
+
 .history-table {
   width: 100%;
   border: 1px solid rgba(251, 192, 45, 0.3);

--- a/src/frontend/src/pages/Profile.css
+++ b/src/frontend/src/pages/Profile.css
@@ -243,6 +243,28 @@
   margin-top: 2.5rem;
 }
 
+.history-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.history-filter-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: rgba(245, 245, 242, 0.85);
+  font-family: 'VT323', monospace;
+  font-size: 1.15rem;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.history-filter-option input {
+  accent-color: var(--primary);
+}
+
 .history-table {
   width: 100%;
   border: 1px solid rgba(251, 192, 45, 0.3);

--- a/src/frontend/src/pages/Profile.jsx
+++ b/src/frontend/src/pages/Profile.jsx
@@ -25,8 +25,8 @@ function buildHistoryUrl(playerId, filters, page) {
     order: filters.sort,
   })
 
-  if (filters.dateFrom) params.set('date_from', filters.dateFrom)
-  if (filters.dateTo) params.set('date_to', filters.dateTo)
+  if (filters.dateFrom) params.set('date_from', `${filters.dateFrom}T00:00:00`)
+  if (filters.dateTo) params.set('date_to', `${filters.dateTo}T23:59:59.999999`)
 
   return `/api/game/matches/history?${params.toString()}`
 }
@@ -128,6 +128,7 @@ export default function Profile() {
     sort: 'date:desc',
   })
   const [historyPage, setHistoryPage] = useState(0)
+  const todayDate = useMemo(() => new Date().toISOString().slice(0, 10), [])
 
   useEffect(() => {
     return () => {
@@ -573,6 +574,44 @@ export default function Profile() {
                       {value === 'all' ? 'All' : value === 'win' ? 'Wins' : 'Losses'}
                     </label>
                   ))}
+                  <label className="history-filter-option history-filter-date">
+                    From
+                    <input
+                      type="date"
+                      value={historyFilters.dateFrom}
+                      max={historyFilters.dateTo || todayDate}
+                      onChange={(e) => {
+                        setHistoryFilters(prev => ({ ...prev, dateFrom: e.target.value }))
+                        setHistoryPage(0)
+                      }}
+                    />
+                  </label>
+                  <label className="history-filter-option history-filter-date">
+                    To
+                    <input
+                      type="date"
+                      value={historyFilters.dateTo}
+                      min={historyFilters.dateFrom}
+                      max={todayDate}
+                      onChange={(e) => {
+                        setHistoryFilters(prev => ({ ...prev, dateTo: e.target.value }))
+                        setHistoryPage(0)
+                      }}
+                    />
+                  </label>
+                  <label className="history-filter-option history-filter-select">
+                    Sort
+                    <select
+                      value={historyFilters.sort}
+                      onChange={(e) => {
+                        setHistoryFilters(prev => ({ ...prev, sort: e.target.value }))
+                        setHistoryPage(0)
+                      }}
+                    >
+                      <option value="date:desc">Date</option>
+                      <option value="result:asc">Result</option>
+                    </select>
+                  </label>
                 </div>
                 {paginatedHistory.total === 0 ? (
                   <p style={{ color: 'var(--metal-silver)', fontFamily: 'VT323, monospace' }}>

--- a/src/frontend/src/pages/Profile.jsx
+++ b/src/frontend/src/pages/Profile.jsx
@@ -16,6 +16,21 @@ const ALLOWED_AVATAR_TYPES = ['image/jpeg', 'image/png', 'image/webp']
 const MAX_AVATAR_BYTES = 2 * 1024 * 1024
 const PLACEHOLDER_AVATAR = '/avatar_placeholder.jpg'
 
+function buildHistoryUrl(playerId, filters, page) {
+  const params = new URLSearchParams({
+    player_id: String(playerId),
+    limit: '10',
+    page: String(page),
+    result: filters.result,
+    order: filters.sort,
+  })
+
+  if (filters.dateFrom) params.set('date_from', filters.dateFrom)
+  if (filters.dateTo) params.set('date_to', filters.dateTo)
+
+  return `/api/game/matches/history?${params.toString()}`
+}
+
 function getSafeAvatarUrl(avatarUrl) {
   if (!avatarUrl || typeof avatarUrl !== 'string') {
     return ''
@@ -105,6 +120,14 @@ export default function Profile() {
   const avatarToastTimer = useRef(null)
   const [xpData, setXpData] = useState(null)
   const [achievements, setAchievements] = useState([])
+
+  const [historyFilters, setHistoryFilters] = useState({
+    dateFrom: '',
+    dateTo: '',
+    result: 'all',
+    sort: 'date:desc',
+  })
+  const [historyPage, setHistoryPage] = useState(0)
 
   useEffect(() => {
     return () => {
@@ -231,7 +254,7 @@ export default function Profile() {
             if (!r.ok) throw new Error(`Profile fetch failed: ${r.status}`)
             return r.json()
           }),
-          apiCall(`/api/game/matches/history?player_id=${id}`, { signal }).then(r => {
+          apiCall(buildHistoryUrl(id, historyFilters, historyPage), { signal }).then(r => {
             if (!r.ok) throw new Error(`Matches History fetch failed: ${r.status}`)
             return r.json()
           }),
@@ -272,7 +295,7 @@ export default function Profile() {
       })
 
     return () => controller.abort()
-  }, [auth.access_token])
+  }, [auth.access_token, historyFilters, historyPage])
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target
@@ -534,6 +557,23 @@ export default function Profile() {
 
               <div className="profile-history">
                 <h2 className="profile-section-title">Match history</h2>
+                <div className="history-controls" role="group" aria-label="Filter match history by result">
+                  {['all', 'win', 'loss'].map((value) => (
+                    <label key={value} className="history-filter-option">
+                      <input
+                        type="radio"
+                        name="historyResult"
+                        value={value}
+                        checked={historyFilters.result === value}
+                        onChange={(e) => {
+                          setHistoryFilters(prev => ({ ...prev, result: e.target.value }))
+                          setHistoryPage(0)
+                        }}
+                      />
+                      {value === 'all' ? 'All' : value === 'win' ? 'Wins' : 'Losses'}
+                    </label>
+                  ))}
+                </div>
                 {paginatedHistory.total === 0 ? (
                   <p style={{ color: 'var(--metal-silver)', fontFamily: 'VT323, monospace' }}>
                     No matches yet.

--- a/src/frontend/src/pages/Profile.jsx
+++ b/src/frontend/src/pages/Profile.jsx
@@ -16,6 +16,13 @@ const ALLOWED_AVATAR_TYPES = ['image/jpeg', 'image/png', 'image/webp']
 const MAX_AVATAR_BYTES = 2 * 1024 * 1024
 const PLACEHOLDER_AVATAR = '/avatar_placeholder.jpg'
 
+const DEFAULT_HISTORY_FILTERS = {
+  dateFrom: '',
+  dateTo: '',
+  result: 'all',
+  sort: 'date:desc',
+}
+
 function buildHistoryUrl(playerId, filters, page) {
   const params = new URLSearchParams({
     player_id: String(playerId),
@@ -120,13 +127,7 @@ export default function Profile() {
   const avatarToastTimer = useRef(null)
   const [xpData, setXpData] = useState(null)
   const [achievements, setAchievements] = useState([])
-
-  const [historyFilters, setHistoryFilters] = useState({
-    dateFrom: '',
-    dateTo: '',
-    result: 'all',
-    sort: 'date:desc',
-  })
+  const [historyFilters, setHistoryFilters] = useState(DEFAULT_HISTORY_FILTERS)
   const [historyPage, setHistoryPage] = useState(0)
   const todayDate = useMemo(() => new Date().toISOString().slice(0, 10), [])
 
@@ -612,6 +613,16 @@ export default function Profile() {
                       <option value="result:asc">Result</option>
                     </select>
                   </label>
+                  <button
+                    type="button"
+                    className="history-clear-button"
+                    onClick={() => {
+                      setHistoryFilters(DEFAULT_HISTORY_FILTERS)
+                      setHistoryPage(0)
+                    }}
+                  >
+                    Clear filters
+                  </button>
                 </div>
                 {paginatedHistory.total === 0 ? (
                   <p style={{ color: 'var(--metal-silver)', fontFamily: 'VT323, monospace' }}>
@@ -642,6 +653,27 @@ export default function Profile() {
                     ))}
                   </div>
                 )}
+                <div className="history-pagination" aria-label="Match history pagination">
+                  <button
+                    type="button"
+                    className="history-page-button"
+                    disabled={paginatedHistory.page <= 0}
+                    onClick={() => setHistoryPage(page => Math.max(0, page - 1))}
+                  >
+                    Previous
+                  </button>
+                  <span className="history-page-summary">
+                    Page {paginatedHistory.page + 1} of {paginatedHistory.last_page + 1} · {paginatedHistory.total} matches
+                  </span>
+                  <button
+                    type="button"
+                    className="history-page-button"
+                    disabled={paginatedHistory.page >= paginatedHistory.last_page}
+                    onClick={() => setHistoryPage(page => page + 1)}
+                  >
+                    Next
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/frontend/src/pages/Profile.jsx
+++ b/src/frontend/src/pages/Profile.jsx
@@ -38,6 +38,13 @@ function buildHistoryUrl(playerId, filters, page) {
   return `/api/game/matches/history?${params.toString()}`
 }
 
+function formatLocalDateInputValue(date = new Date()) {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 function getSafeAvatarUrl(avatarUrl) {
   if (!avatarUrl || typeof avatarUrl !== 'string') {
     return ''
@@ -129,7 +136,7 @@ export default function Profile() {
   const [achievements, setAchievements] = useState([])
   const [historyFilters, setHistoryFilters] = useState(DEFAULT_HISTORY_FILTERS)
   const [historyPage, setHistoryPage] = useState(0)
-  const todayDate = useMemo(() => new Date().toISOString().slice(0, 10), [])
+  const todayDate = formatLocalDateInputValue()
 
   useEffect(() => {
     return () => {
@@ -256,15 +263,11 @@ export default function Profile() {
             if (!r.ok) throw new Error(`Profile fetch failed: ${r.status}`)
             return r.json()
           }),
-          apiCall(buildHistoryUrl(id, historyFilters, historyPage), { signal }).then(r => {
-            if (!r.ok) throw new Error(`Matches History fetch failed: ${r.status}`)
-            return r.json()
-          }),
           apiCall(`/api/game/leaderboard?player_id=${id}&limit=1`, { signal }).then(r => {
             if (!r.ok) throw new Error(`Leaderboard fetch failed: ${r.status}`)
             return r.json()
           }),
-        ]).then(([profileData, historyData, rankData]) => {
+        ]).then(([profileData, rankData]) => {
           setProfile({
             displayName: profileData.display_name ?? '',
             darkMode: profileData.dark_mode ?? false,
@@ -274,7 +277,6 @@ export default function Profile() {
             status: profileData.status,
             createdAt: profileData.created_at,
           })
-          setPaginatedHistory(historyData)
           setUserRankData(rankData.player_stats)
 
           // Fetch XP and achievements after core profile data is loaded (non-blocking)
@@ -297,7 +299,28 @@ export default function Profile() {
       })
 
     return () => controller.abort()
-  }, [auth.access_token, historyFilters, historyPage])
+  }, [auth.access_token])
+
+  useEffect(() => {
+    if (!auth.access_token || !userId) return
+
+    const controller = new AbortController()
+    const { signal } = controller
+
+    apiCall(buildHistoryUrl(userId, historyFilters, historyPage), { signal })
+      .then(r => {
+        if (!r.ok) throw new Error(`Matches History fetch failed: ${r.status}`)
+        return r.json()
+      })
+      .then(data => {
+        if (!signal.aborted) setPaginatedHistory(data)
+      })
+      .catch(err => {
+        if (err.name !== 'AbortError') setError(err.message)
+      })
+
+    return () => controller.abort()
+  }, [auth.access_token, userId, historyFilters, historyPage])
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target
@@ -559,7 +582,7 @@ export default function Profile() {
 
               <div className="profile-history">
                 <h2 className="profile-section-title">Match history</h2>
-                <div className="history-controls" role="group" aria-label="Filter match history by result">
+                <div className="history-controls" role="group" aria-label="Match history filters">
                   {['all', 'win', 'loss'].map((value) => (
                     <label key={value} className="history-filter-option">
                       <input

--- a/src/frontend/src/pages/Profile.test.jsx
+++ b/src/frontend/src/pages/Profile.test.jsx
@@ -31,6 +31,49 @@ vi.mock('../utils/avatarFilter', () => ({
 
 const FAKE_OBJECT_URL = 'blob:fake-object-url'
 
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function defaultProfile({ userId, username, avatarUrl }) {
+  return {
+    id: userId,
+    username,
+    display_name: username === 'alice' ? 'Alice' : username,
+    dark_mode: false,
+    avatar_url: avatarUrl,
+    bio: '',
+    status: 'online',
+    created_at: '2026-01-01',
+  }
+}
+
+function defaultHistory({ userId }) {
+  return {
+    results: [],
+    summary: { player_id: userId, wins: 0, losses: 0, total_matches: 0 },
+    total: 0,
+    page: 0,
+    per_page: 10,
+    last_page: 0,
+  }
+}
+
+function defaultRank({ userId }) {
+  return {
+    player_stats: {
+      player_id: userId,
+      rank: 1,
+      wins: 0,
+      losses: 0,
+      total_matches: 0,
+    },
+  }
+}
+
 function makeImageFile({
   name = 'avatar.png',
   type = 'image/png',
@@ -41,74 +84,48 @@ function makeImageFile({
   return file
 }
 
-function mockProfileBoot({ avatarUrl = '/uploads/avatars/1.png' } = {}) {
-  // Order matches Profile's effect:
-  // 1) GET /api/users/auth/me
-  // 2) GET /api/users/profile/{id}
-  // 3) GET /api/game/matches/history?player_id={id}
-  // 4) GET /api/game/leaderboard?player_id={id}&limit=1
-  // 5) GET /api/game/xp/{id}          (fired after core profile loads)
-  // 6) GET /api/game/achievements/{id} (fired after core profile loads)
-  vi.spyOn(global, 'fetch')
-    .mockResolvedValueOnce(
-      new Response(JSON.stringify({ id: 1, username: 'alice' }), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      })
-    )
-    .mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          id: 1,
-          username: 'alice',
-          display_name: 'Alice',
-          dark_mode: false,
-          avatar_url: avatarUrl,
-          bio: '',
-          status: 'online',
-          created_at: '2026-01-01',
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
-    )
-    .mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          results: [],
-          summary: { player_id: 1, wins: 0, losses: 0, total_matches: 0 },
-          total: 0,
-          page: 1,
-          per_page: 10,
-          last_page: 1,
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
-    )
-    .mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({
-          player_stats: {
-            player_id: 1,
-            rank: 1,
-            wins: 0,
-            losses: 0,
-            total_matches: 0,
-          },
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
-    )
-    // XP response (loaded after core profile)
-    .mockResolvedValueOnce(
-      new Response(
-        JSON.stringify({ user_id: 1, xp: 25, level: 1, xp_in_level: 25, xp_to_next_level: 100 }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } }
-      )
-    )
-    // Achievements response (loaded after core profile)
-    .mockResolvedValueOnce(
-      new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
-    )
+function mockProfileBoot({
+  userId = 1,
+  username = 'alice',
+  avatarUrl = '/uploads/avatars/1.png',
+  profileOverrides = {},
+  historyResponses,
+  rankOverrides = {},
+} = {}) {
+  const historyQueue = [...(historyResponses ?? [defaultHistory({ userId })])]
+  const profile = {
+    ...defaultProfile({ userId, username, avatarUrl }),
+    ...profileOverrides,
+  }
+  const rank = {
+    ...defaultRank({ userId }),
+    ...rankOverrides,
+  }
+
+  vi.spyOn(global, 'fetch').mockImplementation((url) => {
+    const requestUrl = String(url)
+
+    if (requestUrl === '/api/users/auth/me') {
+      return Promise.resolve(jsonResponse({ id: userId, username }))
+    }
+    if (requestUrl === `/api/users/profile/${userId}`) {
+      return Promise.resolve(jsonResponse(profile))
+    }
+    if (requestUrl.startsWith('/api/game/matches/history')) {
+      return Promise.resolve(jsonResponse(historyQueue.shift() ?? defaultHistory({ userId })))
+    }
+    if (requestUrl.startsWith('/api/game/leaderboard')) {
+      return Promise.resolve(jsonResponse(rank))
+    }
+    if (requestUrl === `/api/game/xp/${userId}`) {
+      return Promise.resolve(jsonResponse({ user_id: userId, xp: 25, level: 1, xp_in_level: 25, xp_to_next_level: 100 }))
+    }
+    if (requestUrl === `/api/game/achievements/${userId}`) {
+      return Promise.resolve(jsonResponse([]))
+    }
+
+    return Promise.resolve(new Response('not found', { status: 404 }))
+  })
 }
 
 function renderProfile() {
@@ -117,6 +134,12 @@ function renderProfile() {
       <Profile />
     </MemoryRouter>
   )
+}
+
+function historyRequestUrls() {
+  return global.fetch.mock.calls
+    .map(([url]) => String(url))
+    .filter(url => url.startsWith('/api/game/matches/history'))
 }
 
 describe('Profile avatar UI', () => {
@@ -183,7 +206,6 @@ describe('Profile avatar UI', () => {
     const fileInput = screen.getByLabelText(/choose avatar image/i)
 
     const fetchSpy = global.fetch
-    const callsBefore = fetchSpy.mock.calls.length
 
     fireEvent.change(fileInput, {
       target: { files: [makeImageFile({ type: 'text/plain', name: 'note.txt' })] },
@@ -192,7 +214,11 @@ describe('Profile avatar UI', () => {
     expect(
       await screen.findByText(/only jpeg, png, or webp images are allowed/i)
     ).toBeInTheDocument()
-    expect(fetchSpy.mock.calls.length).toBe(callsBefore)
+    expect(
+      fetchSpy.mock.calls.some(
+        ([url, opts]) => url === '/api/users/avatar' && opts?.method === 'POST'
+      )
+    ).toBe(false)
     expect(
       screen.queryByRole('button', { name: /confirm upload/i })
     ).not.toBeInTheDocument()
@@ -399,114 +425,47 @@ describe('Profile page (general)', () => {
   })
 
   it('renders display name, username and stats from fetched data', async () => {
-    vi.spyOn(global, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ id: 7, username: 'alice' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            id: 7,
-            username: 'alice',
-            display_name: 'Alice the Brave',
-            dark_mode: false,
-            avatar_url: '/uploads/avatars/7.png',
-            bio: 'hi there',
-            status: 'online',
-            created_at: '2026-01-01',
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            results: [],
-            summary: { player_id: 7, wins: 8, losses: 2, total_matches: 10 },
-            total: 0,
-            page: 1,
-            per_page: 10,
-            last_page: 1,
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            player_stats: {
-              player_id: 7,
-              rank: 5,
-              wins: 8,
-              losses: 2,
-              total_matches: 10,
-            },
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
+    mockProfileBoot({
+      userId: 7,
+      username: 'alice',
+      avatarUrl: '/uploads/avatars/7.png',
+      profileOverrides: {
+        display_name: 'Alice the Brave',
+        bio: 'hi there',
+      },
+      historyResponses: [{
+        results: [],
+        summary: { player_id: 7, wins: 8, losses: 2, total_matches: 10 },
+        total: 0,
+        page: 0,
+        per_page: 10,
+        last_page: 0,
+      }],
+      rankOverrides: {
+        player_stats: {
+          player_id: 7,
+          rank: 5,
+          wins: 8,
+          losses: 2,
+          total_matches: 10,
+        },
+      },
+    })
 
     renderProfile()
     expect(await screen.findByText('Alice the Brave')).toBeInTheDocument()
     expect(screen.getByText('@alice')).toBeInTheDocument()
-    expect(screen.getByText('8')).toBeInTheDocument() // wins
+    expect(await screen.findByText('8')).toBeInTheDocument() // wins
     expect(screen.getByText('10')).toBeInTheDocument() // total matches
     expect(screen.getByDisplayValue('hi there')).toBeInTheDocument()
   })
 
   it('falls back to username when display_name is empty', async () => {
-    vi.spyOn(global, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ id: 1, username: 'solo' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            id: 1,
-            username: 'solo',
-            display_name: '',
-            dark_mode: false,
-            avatar_url: null,
-            bio: '',
-            status: 'online',
-            created_at: '2026-01-01',
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            results: [],
-            summary: { player_id: 1, wins: 0, losses: 0, total_matches: 0 },
-            total: 0,
-            page: 1,
-            per_page: 10,
-            last_page: 1,
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            player_stats: {
-              player_id: 1,
-              rank: 1,
-              wins: 0,
-              losses: 0,
-              total_matches: 0,
-            },
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
+    mockProfileBoot({
+      username: 'solo',
+      avatarUrl: null,
+      profileOverrides: { display_name: '' },
+    })
 
     renderProfile()
     const heading = await screen.findByRole('heading', { name: 'solo' })
@@ -520,70 +479,41 @@ describe('Profile page (general)', () => {
   })
 
   it('renders match history rows when results are present', async () => {
-    vi.spyOn(global, 'fetch')
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ id: 1, username: 'alice' }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            id: 1,
-            username: 'alice',
-            display_name: 'Alice',
-            dark_mode: false,
-            avatar_url: null,
-            bio: '',
-            status: 'online',
-            created_at: '2026-01-01',
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            results: [
-              {
-                match_id: 100,
-                opponent_id: 42,
-                date: '2026-04-01T12:00:00Z',
-                result: 'win',
-                score: '3-1',
-              },
-              {
-                match_id: 101,
-                opponent_id: 99,
-                date: '2026-04-02T12:00:00Z',
-                result: 'loss',
-                score: '0-3',
-              },
-            ],
-            summary: { player_id: 1, wins: 1, losses: 1, total_matches: 2 },
-            total: 2,
-            page: 1,
-            per_page: 10,
-            last_page: 1,
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            player_stats: {
-              player_id: 1,
-              rank: 10,
-              wins: 1,
-              losses: 1,
-              total_matches: 2,
-            },
-          }),
-          { status: 200, headers: { 'Content-Type': 'application/json' } }
-        )
-      )
+    mockProfileBoot({
+      avatarUrl: null,
+      historyResponses: [{
+        results: [
+          {
+            match_id: 100,
+            opponent_id: 42,
+            date: '2026-04-01T12:00:00Z',
+            result: 'win',
+            score: '3-1',
+          },
+          {
+            match_id: 101,
+            opponent_id: 99,
+            date: '2026-04-02T12:00:00Z',
+            result: 'loss',
+            score: '0-3',
+          },
+        ],
+        summary: { player_id: 1, wins: 1, losses: 1, total_matches: 2 },
+        total: 2,
+        page: 0,
+        per_page: 10,
+        last_page: 0,
+      }],
+      rankOverrides: {
+        player_stats: {
+          player_id: 1,
+          rank: 10,
+          wins: 1,
+          losses: 1,
+          total_matches: 2,
+        },
+      },
+    })
 
     renderProfile()
     expect(await screen.findByText('Player #42')).toBeInTheDocument()
@@ -591,6 +521,113 @@ describe('Profile page (general)', () => {
     expect(screen.getByText('3-1')).toBeInTheDocument()
     expect(screen.getByText('0-3')).toBeInTheDocument()
     expect(screen.queryByText(/no matches yet/i)).not.toBeInTheDocument()
+  })
+
+  it('re-fetches match history with filter params and keeps profile data loaded once', async () => {
+    mockProfileBoot({
+      historyResponses: [
+        defaultHistory({ userId: 1 }),
+        defaultHistory({ userId: 1 }),
+        defaultHistory({ userId: 1 }),
+        defaultHistory({ userId: 1 }),
+      ],
+    })
+    renderProfile()
+
+    await screen.findByLabelText(/^wins$/i)
+    await waitFor(() => expect(historyRequestUrls()).toHaveLength(1))
+
+    fireEvent.click(screen.getByLabelText(/^wins$/i))
+    await waitFor(() => {
+      const params = new URLSearchParams(historyRequestUrls().at(-1).split('?')[1])
+      expect(params.get('result')).toBe('win')
+      expect(params.get('page')).toBe('0')
+    })
+
+    fireEvent.change(screen.getByLabelText(/^from$/i), { target: { value: '2026-04-01' } })
+    await waitFor(() => {
+      const params = new URLSearchParams(historyRequestUrls().at(-1).split('?')[1])
+      expect(params.get('date_from')).toBe('2026-04-01T00:00:00')
+      expect(params.get('page')).toBe('0')
+    })
+
+    fireEvent.change(screen.getByLabelText(/^to$/i), { target: { value: '2026-04-28' } })
+    fireEvent.change(screen.getByLabelText(/^sort$/i), { target: { value: 'result:asc' } })
+    await waitFor(() => {
+      const params = new URLSearchParams(historyRequestUrls().at(-1).split('?')[1])
+      expect(params.get('date_to')).toBe('2026-04-28T23:59:59.999999')
+      expect(params.get('order')).toBe('result:asc')
+      expect(params.get('page')).toBe('0')
+    })
+
+    const profileLoads = global.fetch.mock.calls.filter(
+      ([url]) => String(url) === '/api/users/profile/1'
+    )
+    expect(profileLoads).toHaveLength(1)
+  })
+
+  it('clears match history filters back to defaults', async () => {
+    mockProfileBoot({
+      historyResponses: [
+        defaultHistory({ userId: 1 }),
+        defaultHistory({ userId: 1 }),
+        defaultHistory({ userId: 1 }),
+      ],
+    })
+    renderProfile()
+
+    await screen.findByRole('button', { name: /clear filters/i })
+    fireEvent.click(screen.getByLabelText(/^losses$/i))
+    fireEvent.change(screen.getByLabelText(/^from$/i), { target: { value: '2026-04-01' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /clear filters/i }))
+
+    await waitFor(() => {
+      const params = new URLSearchParams(historyRequestUrls().at(-1).split('?')[1])
+      expect(params.get('result')).toBe('all')
+      expect(params.get('order')).toBe('date:desc')
+      expect(params.get('page')).toBe('0')
+      expect(params.has('date_from')).toBe(false)
+      expect(params.has('date_to')).toBe(false)
+    })
+  })
+
+  it('uses next and previous buttons to request the selected history page', async () => {
+    const firstPage = {
+      ...defaultHistory({ userId: 1 }),
+      total: 11,
+      page: 0,
+      last_page: 1,
+    }
+    const secondPage = {
+      ...defaultHistory({ userId: 1 }),
+      total: 11,
+      page: 1,
+      last_page: 1,
+    }
+
+    mockProfileBoot({
+      historyResponses: [firstPage, secondPage, firstPage],
+    })
+    renderProfile()
+
+    const nextButton = await screen.findByRole('button', { name: /^next$/i })
+    await waitFor(() => expect(nextButton).not.toBeDisabled())
+
+    fireEvent.click(nextButton)
+    await waitFor(() => {
+      const params = new URLSearchParams(historyRequestUrls().at(-1).split('?')[1])
+      expect(params.get('page')).toBe('1')
+    })
+
+    const previousButton = screen.getByRole('button', { name: /^previous$/i })
+    await waitFor(() => expect(previousButton).not.toBeDisabled())
+
+    fireEvent.click(previousButton)
+    await waitFor(() => {
+      const params = new URLSearchParams(historyRequestUrls().at(-1).split('?')[1])
+      expect(params.get('page')).toBe('0')
+    })
   })
 
   it('Save profile sends PUT with display name, bio and dark mode', async () => {


### PR DESCRIPTION
Closes #

Implemented the match history filter controls for the profile page.

### Added

- Result filter: All / Wins / Losses
- Date range filters: From / To
- Sort selector: Date / Result
- Clear filters button
- Previous / Next pagination controls
- Current page and total match count display

### Notes

The frontend now re-fetches match history whenever filters, sort, or page change, using the existing `/api/game/matches/history` endpoint.

Date filters are sent as full-day ranges:
- `date_from=YYYY-MM-DDT00:00:00`
- `date_to=YYYY-MM-DDT23:59:59.999999`

### Validation

- Manually validated requests in browser Network tab.
- Ran focused frontend tests:

```bash
Ran make check - all tests ok


Closes #226