### PR TITLE
feat(frontend): add navbar user search and paginated search page

### DIFF
--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -17,6 +17,7 @@ import GamePage from './pages/GamePage'
 import GameInviteModal from './Components/GameInviteModal'
 import Tournament from './pages/Tournament'
 import Tournaments from './pages/Tournaments'
+import Search from './pages/Search'
 
 export default function App() {
   useEffect(() => {
@@ -59,6 +60,24 @@ export default function App() {
           element={(
             <PrivateRoute>
               <Profile />
+            </PrivateRoute>
+          )}
+        />
+
+        <Route
+          path="/profile/:profileUserId"
+          element={(
+            <PrivateRoute>
+              <Profile />
+            </PrivateRoute>
+          )}
+        />
+
+        <Route
+          path="/search"
+          element={(
+            <PrivateRoute>
+              <Search />
             </PrivateRoute>
           )}
         />
@@ -117,4 +136,3 @@ export default function App() {
     </BrowserRouter>
   )
 }
-

--- a/src/frontend/src/App.test.jsx
+++ b/src/frontend/src/App.test.jsx
@@ -20,6 +20,7 @@ vi.mock('./pages/GameWaitingRoom', () => ({ default: () => <div data-testid="pag
 vi.mock('./pages/GamePage', () => ({ default: () => <div data-testid="page-game" /> }))
 vi.mock('./pages/Tournament', () => ({ default: () => <div data-testid="page-tournament" /> }))
 vi.mock('./pages/Tournaments', () => ({ default: () => <div data-testid="page-tournaments" /> }))
+vi.mock('./pages/Search', () => ({ default: () => <div data-testid="page-search" /> }))
 vi.mock('./Components/PongCanvas', () => ({ default: () => <div data-testid="pong-canvas" /> }))
 vi.mock('./Components/PrivateRoute', () => ({
   default: ({ children }) => <>{children}</>,
@@ -53,6 +54,12 @@ describe('App', () => {
     window.history.pushState({}, '', '/leaderboard')
     render(<App />)
     expect(screen.getByTestId('page-leaderboard')).toBeInTheDocument()
+  })
+
+  it('routes /search to the Search page', () => {
+    window.history.pushState({}, '', '/search?q=alice')
+    render(<App />)
+    expect(screen.getByTestId('page-search')).toBeInTheDocument()
   })
 
   it('attaches inactivity listeners on mount and detaches on unmount', () => {

--- a/src/frontend/src/Components/Navbar.css
+++ b/src/frontend/src/Components/Navbar.css
@@ -133,6 +133,111 @@
   gap: 0.75rem;
 }
 
+.pong-nav__search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  min-width: 230px;
+}
+
+.pong-nav__search-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  padding: 0;
+  border: 3px solid #3b241d;
+  border-radius: 12px;
+  background: rgba(59, 36, 29, 0.1);
+  color: #3b241d;
+  cursor: pointer;
+}
+
+.pong-nav__search-form {
+  width: 100%;
+}
+
+.pong-nav__search-input {
+  width: 100%;
+  min-height: 48px;
+  padding: 0.7rem 0.8rem;
+  border: 3px solid #3b241d;
+  border-radius: 12px;
+  background: rgba(255, 249, 213, 0.9);
+  color: #3b241d;
+  font-family: 'VT323', monospace;
+  font-size: 1.1rem;
+  line-height: 1;
+  outline: none;
+}
+
+.pong-nav__search-input::placeholder {
+  color: rgba(59, 36, 29, 0.65);
+}
+
+.pong-nav__search-input:focus {
+  box-shadow: 0 0 0 3px rgba(59, 36, 29, 0.18);
+}
+
+.pong-nav__search-dropdown {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  right: 0;
+  z-index: 10020;
+  width: min(320px, 80vw);
+  padding: 0.45rem;
+  border: 3px solid #3b241d;
+  border-radius: 12px;
+  background: #fff3a8;
+  box-shadow: 0 6px 0 rgba(59, 36, 29, 0.35);
+}
+
+.pong-nav__search-result,
+.pong-nav__search-all,
+.pong-nav__search-status {
+  width: 100%;
+  min-height: 42px;
+  padding: 0.45rem 0.55rem;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: #3b241d;
+  font-family: 'VT323', monospace;
+  font-size: 1.05rem;
+  text-align: left;
+}
+
+.pong-nav__search-result {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  cursor: pointer;
+}
+
+.pong-nav__search-result:hover,
+.pong-nav__search-all:hover {
+  background: rgba(59, 36, 29, 0.12);
+}
+
+.pong-nav__search-avatar {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 30px;
+  border: 2px solid #3b241d;
+  border-radius: 50%;
+  object-fit: cover;
+  background: #f6db58;
+}
+
+.pong-nav__search-all {
+  display: block;
+  margin-top: 0.25rem;
+  border-top: 2px solid rgba(59, 36, 29, 0.18);
+  text-decoration: none;
+  text-align: center;
+}
+
 .pong-nav__button {
   display: inline-flex;
   align-items: center;
@@ -252,6 +357,11 @@
 
   .pong-nav__actions {
     justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .pong-nav__search {
+    width: min(360px, 100%);
   }
 }
 
@@ -304,6 +414,32 @@
     display: grid;
     grid-template-columns: 1fr;
     gap: 0.6rem;
+  }
+
+  .pong-nav__search {
+    display: grid;
+    grid-template-columns: 52px 1fr;
+    gap: 0.5rem;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .pong-nav__search-toggle {
+    display: inline-flex;
+  }
+
+  .pong-nav__search-form {
+    display: none;
+  }
+
+  .pong-nav__search.is-open .pong-nav__search-form {
+    display: block;
+  }
+
+  .pong-nav__search-dropdown {
+    left: 0;
+    right: auto;
+    width: 100%;
   }
 }
 
@@ -362,5 +498,4 @@
   border-radius: 8px;
   border: 2px solid #3b241d;
   vertical-align: middle;
-}
 }

--- a/src/frontend/src/Components/Navbar.css
+++ b/src/frontend/src/Components/Navbar.css
@@ -137,11 +137,14 @@
   position: relative;
   display: flex;
   align-items: center;
+}
+
+.pong-nav__search.is-open {
   min-width: 230px;
 }
 
 .pong-nav__search-toggle {
-  display: none;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 48px;
@@ -414,26 +417,6 @@
     display: grid;
     grid-template-columns: 1fr;
     gap: 0.6rem;
-  }
-
-  .pong-nav__search {
-    display: grid;
-    grid-template-columns: 52px 1fr;
-    gap: 0.5rem;
-    width: 100%;
-    min-width: 0;
-  }
-
-  .pong-nav__search-toggle {
-    display: inline-flex;
-  }
-
-  .pong-nav__search-form {
-    display: none;
-  }
-
-  .pong-nav__search.is-open .pong-nav__search-form {
-    display: block;
   }
 
   .pong-nav__search-dropdown {

--- a/src/frontend/src/Components/Navbar.css
+++ b/src/frontend/src/Components/Navbar.css
@@ -144,17 +144,17 @@
 }
 
 .pong-nav__search-toggle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 48px;
-  height: 48px;
-  padding: 0;
-  border: 3px solid #3b241d;
-  border-radius: 12px;
-  background: rgba(59, 36, 29, 0.1);
-  color: #3b241d;
+  background: none;
+  border: none;
   cursor: pointer;
+  font-size: 1.3rem;
+  line-height: 1;
+  padding: 0.25rem;
+  color: #3b241d;
+}
+
+.pong-nav__search-toggle:hover {
+  opacity: 0.8;
 }
 
 .pong-nav__search-form {

--- a/src/frontend/src/Components/Navbar.jsx
+++ b/src/frontend/src/Components/Navbar.jsx
@@ -95,11 +95,12 @@ export default function NavbarComponent() {
     setIsMenuOpen(false)
     setIsSearchOpen(false)
     setIsSearchFocused(false)
+    setSearchTerm('')
   }, [location.pathname])
 
   useEffect(() => {
     const query = searchTerm.trim()
-    if (!query) {
+    if (!isAuthenticated || !query) {
       setSearchResults([])
       setSearchTotal(0)
       setSearchError('')
@@ -144,7 +145,7 @@ export default function NavbarComponent() {
       clearTimeout(timeoutId)
       controller.abort()
     }
-  }, [searchTerm])
+  }, [searchTerm, isAuthenticated])
 
   const handleToggleMenu = () => {
     setIsMenuOpen((prev) => !prev)

--- a/src/frontend/src/Components/Navbar.jsx
+++ b/src/frontend/src/Components/Navbar.jsx
@@ -150,6 +150,15 @@ export default function NavbarComponent() {
     setIsSearchOpen(false)
   }
 
+  const handleToggleSearch = () => {
+    if (isSearchOpen) {
+      closeSearch()
+      return
+    }
+
+    setIsSearchOpen(true)
+  }
+
   const goToUserProfile = (userId) => {
     navigate(`/profile/${userId}`)
     closeSearch()
@@ -212,7 +221,7 @@ export default function NavbarComponent() {
                     type="button"
                     className="pong-nav__search-toggle"
                     aria-label={isSearchOpen ? 'Close user search' : 'Open user search'}
-                    onClick={() => setIsSearchOpen(prev => !prev)}
+                    onClick={handleToggleSearch}
                   >
                     🔍
                   </button>

--- a/src/frontend/src/Components/Navbar.jsx
+++ b/src/frontend/src/Components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/authContext'
 import { useNotifications } from '../context/notificationContext'
@@ -67,6 +67,14 @@ export default function NavbarComponent() {
   const [searchError, setSearchError] = useState('')
   const [isSearchOpen, setIsSearchOpen] = useState(false)
   const [isSearchFocused, setIsSearchFocused] = useState(false)
+
+  const searchInputRef = useRef(null)
+
+  useEffect(() => {
+    if (isSearchOpen) {
+      searchInputRef.current?.focus()
+    }
+  }, [isSearchOpen])
 
   const dmUnreadTotal = Object.values(unreadCounts).reduce((a, b) => a + b, 0)
 
@@ -223,35 +231,44 @@ export default function NavbarComponent() {
             {isAuthenticated ? (
               <div className="pong-nav__actions">
                 <div className={`pong-nav__search ${isSearchOpen ? 'is-open' : ''}`}>
-                  <button
-                    type="button"
-                    className="pong-nav__search-toggle"
-                    aria-label={isSearchOpen ? 'Close user search' : 'Open user search'}
-                    onClick={handleToggleSearch}
-                  >
-                    🔍
-                  </button>
-                  <form className="pong-nav__search-form" role="search" onSubmit={goToFullSearch}>
-                    <input
-                      type="search"
-                      className="pong-nav__search-input"
-                      aria-label="Search users"
-                      placeholder="Search users"
-                      value={searchTerm}
-                      onFocus={() => setIsSearchFocused(true)}
-                      onBlur={(event) => {
-                        const nextFocusedElement = event.relatedTarget
-                        const searchContainer = event.currentTarget.closest('.pong-nav__search')
+                  {!isSearchOpen ? (
+                    <button
+                      type="button"
+                      className="pong-nav__search-toggle"
+                      aria-label="Open user search"
+                      onClick={handleToggleSearch}
+                    >
+                      🔍
+                    </button>
+                  ) : (
+                    <form className="pong-nav__search-form" role="search" onSubmit={goToFullSearch}>
+                      <input
+                        ref={searchInputRef}
+                        type="search"
+                        className="pong-nav__search-input"
+                        aria-label="Search users"
+                        placeholder="Search users"
+                        value={searchTerm}
+                        onFocus={() => setIsSearchFocused(true)}
+                        onBlur={(event) => {
+                          const nextFocusedElement = event.relatedTarget
+                          const searchContainer = event.currentTarget.closest('.pong-nav__search')
 
-                        if (searchContainer?.contains(nextFocusedElement)) {
-                          return
-                        }
+                          if (searchContainer?.contains(nextFocusedElement)) {
+                            return
+                          }
 
-                        setIsSearchFocused(false)
-                      }}
-                      onChange={(event) => setSearchTerm(event.target.value)}
-                    />
-                  </form>
+                          closeSearch()
+                        }}
+                        onChange={(event) => setSearchTerm(event.target.value)}
+                        onKeyDown={(event) => {
+                          if (event.key === 'Escape') {
+                            closeSearch()
+                          }
+                        }}
+                      />
+                    </form>
+                  )}
                   {shouldShowSearchDropdown && (
                     <div className="pong-nav__search-dropdown" aria-label="User search results">
                       {searchLoading && (

--- a/src/frontend/src/Components/Navbar.jsx
+++ b/src/frontend/src/Components/Navbar.jsx
@@ -247,7 +247,7 @@ export default function NavbarComponent() {
                     />
                   </form>
                   {shouldShowSearchDropdown && (
-                    <div className="pong-nav__search-dropdown" role="listbox" aria-label="User search results">
+                    <div className="pong-nav__search-dropdown" aria-label="User search results">
                       {searchLoading && (
                         <div className="pong-nav__search-status">Searching...</div>
                       )}
@@ -262,7 +262,6 @@ export default function NavbarComponent() {
                           key={user.id}
                           type="button"
                           className="pong-nav__search-result"
-                          role="option"
                           onMouseDown={(event) => event.preventDefault()}
                           onClick={() => goToUserProfile(user.id)}
                         >

--- a/src/frontend/src/Components/Navbar.jsx
+++ b/src/frontend/src/Components/Navbar.jsx
@@ -50,6 +50,8 @@ const privateLinks = [
   },
 ]
 
+const NAVBAR_SEARCH_LIMIT = 5
+
 export default function NavbarComponent() {
   const location = useLocation()
   const navigate = useNavigate()
@@ -101,7 +103,7 @@ export default function NavbarComponent() {
     const timeoutId = setTimeout(() => {
       setSearchLoading(true)
       setSearchError('')
-      apiCall(`/api/users/search?q=${encodeURIComponent(query)}&page=1&per_page=5&sort=username`, {
+      apiCall(`/api/users/search?q=${encodeURIComponent(query)}&page=1&per_page=${NAVBAR_SEARCH_LIMIT}&sort=username`, {
         signal: controller.signal,
         skipRefreshOn401: true,
       })
@@ -111,7 +113,11 @@ export default function NavbarComponent() {
         })
         .then(data => {
           if (controller.signal.aborted) return
-          setSearchResults(Array.isArray(data.results) ? data.results : [])
+          setSearchResults(
+            Array.isArray(data.results)
+              ? data.results.slice(0, NAVBAR_SEARCH_LIMIT)
+              : []
+          )
           setSearchTotal(Number.isFinite(data.total) ? data.total : 0)
         })
         .catch(err => {

--- a/src/frontend/src/Components/Navbar.jsx
+++ b/src/frontend/src/Components/Navbar.jsx
@@ -224,6 +224,16 @@ export default function NavbarComponent() {
                       placeholder="Search users"
                       value={searchTerm}
                       onFocus={() => setIsSearchFocused(true)}
+                      onBlur={(event) => {
+                        const nextFocusedElement = event.relatedTarget
+                        const searchContainer = event.currentTarget.closest('.pong-nav__search')
+
+                        if (searchContainer?.contains(nextFocusedElement)) {
+                          return
+                        }
+
+                        setIsSearchFocused(false)
+                      }}
                       onChange={(event) => setSearchTerm(event.target.value)}
                     />
                   </form>

--- a/src/frontend/src/Components/Navbar.jsx
+++ b/src/frontend/src/Components/Navbar.jsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useAuth } from '../context/authContext'
 import { useNotifications } from '../context/notificationContext'
 import { useUnread } from '../context/unreadContext'
+import { apiCall } from '../utils/apiClient'
 import NotificationPanel from './NotificationPanel'
 import './Navbar.css'
 
@@ -51,11 +52,19 @@ const privateLinks = [
 
 export default function NavbarComponent() {
   const location = useLocation()
+  const navigate = useNavigate()
   const { logout, isAuthenticated } = useAuth()
   const { unreadCount } = useNotifications()
   const { unreadCounts } = useUnread()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isPanelOpen, setIsPanelOpen] = useState(false)
+  const [searchTerm, setSearchTerm] = useState('')
+  const [searchResults, setSearchResults] = useState([])
+  const [searchTotal, setSearchTotal] = useState(0)
+  const [searchLoading, setSearchLoading] = useState(false)
+  const [searchError, setSearchError] = useState('')
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [isSearchFocused, setIsSearchFocused] = useState(false)
 
   const dmUnreadTotal = Object.values(unreadCounts).reduce((a, b) => a + b, 0)
 
@@ -74,7 +83,54 @@ export default function NavbarComponent() {
 
   useEffect(() => {
     setIsMenuOpen(false)
+    setIsSearchOpen(false)
+    setIsSearchFocused(false)
   }, [location.pathname])
+
+  useEffect(() => {
+    const query = searchTerm.trim()
+    if (!query) {
+      setSearchResults([])
+      setSearchTotal(0)
+      setSearchError('')
+      setSearchLoading(false)
+      return undefined
+    }
+
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => {
+      setSearchLoading(true)
+      setSearchError('')
+      apiCall(`/api/users/search?q=${encodeURIComponent(query)}&page=1&per_page=5&sort=username`, {
+        signal: controller.signal,
+        skipRefreshOn401: true,
+      })
+        .then(r => {
+          if (!r.ok) throw new Error(`Search failed: ${r.status}`)
+          return r.json()
+        })
+        .then(data => {
+          if (controller.signal.aborted) return
+          setSearchResults(Array.isArray(data.results) ? data.results : [])
+          setSearchTotal(Number.isFinite(data.total) ? data.total : 0)
+        })
+        .catch(err => {
+          if (err.name !== 'AbortError') {
+            setSearchResults([])
+            setSearchTotal(0)
+            setSearchError('Search unavailable')
+          }
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) setSearchLoading(false)
+        })
+    }, 300)
+
+    return () => {
+      clearTimeout(timeoutId)
+      controller.abort()
+    }
+  }, [searchTerm])
 
   const handleToggleMenu = () => {
     setIsMenuOpen((prev) => !prev)
@@ -84,6 +140,32 @@ export default function NavbarComponent() {
     logout()
     setIsMenuOpen(false)
   }
+
+  const closeSearch = () => {
+    setSearchTerm('')
+    setSearchResults([])
+    setSearchTotal(0)
+    setSearchError('')
+    setIsSearchFocused(false)
+    setIsSearchOpen(false)
+  }
+
+  const goToUserProfile = (userId) => {
+    navigate(`/profile/${userId}`)
+    closeSearch()
+    setIsMenuOpen(false)
+  }
+
+  const goToFullSearch = (event) => {
+    event.preventDefault()
+    const query = searchTerm.trim()
+    if (!query) return
+    navigate(`/search?q=${encodeURIComponent(query)}`)
+    closeSearch()
+    setIsMenuOpen(false)
+  }
+
+  const shouldShowSearchDropdown = isSearchFocused && searchTerm.trim().length > 0
 
   return (
     <header className="pong-nav">
@@ -125,6 +207,67 @@ export default function NavbarComponent() {
 
             {isAuthenticated ? (
               <div className="pong-nav__actions">
+                <div className={`pong-nav__search ${isSearchOpen ? 'is-open' : ''}`}>
+                  <button
+                    type="button"
+                    className="pong-nav__search-toggle"
+                    aria-label={isSearchOpen ? 'Close user search' : 'Open user search'}
+                    onClick={() => setIsSearchOpen(prev => !prev)}
+                  >
+                    🔍
+                  </button>
+                  <form className="pong-nav__search-form" role="search" onSubmit={goToFullSearch}>
+                    <input
+                      type="search"
+                      className="pong-nav__search-input"
+                      aria-label="Search users"
+                      placeholder="Search users"
+                      value={searchTerm}
+                      onFocus={() => setIsSearchFocused(true)}
+                      onChange={(event) => setSearchTerm(event.target.value)}
+                    />
+                  </form>
+                  {shouldShowSearchDropdown && (
+                    <div className="pong-nav__search-dropdown" role="listbox" aria-label="User search results">
+                      {searchLoading && (
+                        <div className="pong-nav__search-status">Searching...</div>
+                      )}
+                      {!searchLoading && searchError && (
+                        <div className="pong-nav__search-status">{searchError}</div>
+                      )}
+                      {!searchLoading && !searchError && searchResults.length === 0 && (
+                        <div className="pong-nav__search-status">No users found</div>
+                      )}
+                      {!searchLoading && !searchError && searchResults.map(user => (
+                        <button
+                          key={user.id}
+                          type="button"
+                          className="pong-nav__search-result"
+                          role="option"
+                          onMouseDown={(event) => event.preventDefault()}
+                          onClick={() => goToUserProfile(user.id)}
+                        >
+                          <img
+                            src={user.avatar_url || '/avatar_placeholder.jpg'}
+                            alt=""
+                            className="pong-nav__search-avatar"
+                          />
+                          <span>{user.username}</span>
+                        </button>
+                      ))}
+                      {!searchLoading && !searchError && searchTotal > 0 && (
+                        <Link
+                          to={`/search?q=${encodeURIComponent(searchTerm.trim())}`}
+                          className="pong-nav__search-all"
+                          onMouseDown={(event) => event.preventDefault()}
+                          onClick={goToFullSearch}
+                        >
+                          See all results
+                        </Link>
+                      )}
+                    </div>
+                  )}
+                </div>
                 <div className="pong-nav__bell-wrap">
                   <button
                     type="button"

--- a/src/frontend/src/Components/Navbar.test.jsx
+++ b/src/frontend/src/Components/Navbar.test.jsx
@@ -108,6 +108,7 @@ describe('Navbar — bell and DM badge', () => {
         )
 
         renderNavbar()
+        fireEvent.click(screen.getByRole('button', { name: /open user search/i }))
         const searchInput = screen.getByRole('searchbox', { name: /search users/i })
 
         fireEvent.focus(searchInput)
@@ -132,5 +133,49 @@ describe('Navbar — bell and DM badge', () => {
 
         expect(await screen.findByText('alice')).toBeInTheDocument()
         expect(screen.getByRole('link', { name: /see all results/i })).toHaveAttribute('href', '/search?q=ali')
+    })
+
+    it('shows the search toggle and hides the input by default', () => {
+        renderNavbar()
+        expect(
+            screen.getByRole('button', { name: /open user search/i })
+        ).toBeInTheDocument()
+        expect(
+            screen.queryByRole('searchbox', { name: /search users/i })
+        ).not.toBeInTheDocument()
+    })
+
+    it('clicking the toggle reveals the input and auto-focuses it', async () => {
+        renderNavbar()
+        const toggle = screen.getByRole('button', { name: /open user search/i })
+
+        fireEvent.click(toggle)
+
+        const input = await screen.findByRole('searchbox', { name: /search users/i })
+        expect(input).toBeInTheDocument()
+        await waitFor(() => {
+            expect(document.activeElement).toBe(input)
+        })
+        expect(
+            screen.queryByRole('button', { name: /open user search/i })
+        ).not.toBeInTheDocument()
+    })
+
+    it('pressing Escape in the input closes the search and restores the toggle', async () => {
+        renderNavbar()
+        fireEvent.click(screen.getByRole('button', { name: /open user search/i }))
+
+        const input = await screen.findByRole('searchbox', { name: /search users/i })
+        fireEvent.change(input, { target: { value: 'al' } })
+        fireEvent.keyDown(input, { key: 'Escape', code: 'Escape' })
+
+        await waitFor(() => {
+            expect(
+                screen.queryByRole('searchbox', { name: /search users/i })
+            ).not.toBeInTheDocument()
+        })
+        expect(
+            screen.getByRole('button', { name: /open user search/i })
+        ).toBeInTheDocument()
     })
 })

--- a/src/frontend/src/Components/Navbar.test.jsx
+++ b/src/frontend/src/Components/Navbar.test.jsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import NavbarComponent from './Navbar'
 
@@ -29,6 +29,10 @@ describe('Navbar — bell and DM badge', () => {
         useAuth.mockReturnValue({ isAuthenticated: true, logout: vi.fn() })
         useNotifications.mockReturnValue({ unreadCount: 0 })
         useUnread.mockReturnValue({ unreadCounts: {} })
+    })
+
+    afterEach(() => {
+        vi.restoreAllMocks()
     })
 
     it('shows bell button when authenticated', () => {
@@ -88,5 +92,32 @@ describe('Navbar — bell and DM badge', () => {
         useUnread.mockReturnValue({ unreadCounts: { 'DM-1-2': 2, 'DM-1-3': 1 } })
         renderNavbar()
         expect(screen.queryByTestId('dm-badge')).toBeNull()
+    })
+
+    it('debounces user search and renders dropdown results', async () => {
+        vi.spyOn(global, 'fetch').mockResolvedValue(
+            new Response(JSON.stringify({
+                results: [{ id: 7, username: 'alice', avatar_url: '/avatars/alice.png' }],
+                total: 1,
+                page: 1,
+                per_page: 5,
+            }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+        )
+
+        renderNavbar()
+        const searchInput = screen.getByRole('searchbox', { name: /search users/i })
+        fireEvent.focus(searchInput)
+        fireEvent.change(searchInput, {
+            target: { value: 'ali' },
+        })
+
+        await waitFor(() => {
+            expect(global.fetch).toHaveBeenCalledWith(
+                '/api/users/search?q=ali&page=1&per_page=5&sort=username',
+                expect.objectContaining({ signal: expect.any(AbortSignal) })
+            )
+        })
+        expect(await screen.findByText('alice')).toBeInTheDocument()
+        expect(screen.getByRole('link', { name: /see all results/i })).toHaveAttribute('href', '/search?q=ali')
     })
 })

--- a/src/frontend/src/Components/Navbar.test.jsx
+++ b/src/frontend/src/Components/Navbar.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import NavbarComponent from './Navbar'
 
@@ -32,6 +32,7 @@ describe('Navbar — bell and DM badge', () => {
     })
 
     afterEach(() => {
+        vi.useRealTimers()
         vi.restoreAllMocks()
     })
 
@@ -95,6 +96,8 @@ describe('Navbar — bell and DM badge', () => {
     })
 
     it('debounces user search and renders dropdown results', async () => {
+        vi.useFakeTimers()
+
         vi.spyOn(global, 'fetch').mockResolvedValue(
             new Response(JSON.stringify({
                 results: [{ id: 7, username: 'alice', avatar_url: '/avatars/alice.png' }],
@@ -106,10 +109,19 @@ describe('Navbar — bell and DM badge', () => {
 
         renderNavbar()
         const searchInput = screen.getByRole('searchbox', { name: /search users/i })
+
         fireEvent.focus(searchInput)
         fireEvent.change(searchInput, {
             target: { value: 'ali' },
         })
+
+        expect(global.fetch).not.toHaveBeenCalled()
+
+        await act(async () => {
+            vi.advanceTimersByTime(300)
+        })
+
+        vi.useRealTimers()
 
         await waitFor(() => {
             expect(global.fetch).toHaveBeenCalledWith(
@@ -117,6 +129,7 @@ describe('Navbar — bell and DM badge', () => {
                 expect.objectContaining({ signal: expect.any(AbortSignal) })
             )
         })
+
         expect(await screen.findByText('alice')).toBeInTheDocument()
         expect(screen.getByRole('link', { name: /see all results/i })).toHaveAttribute('href', '/search?q=ali')
     })

--- a/src/frontend/src/pages/Profile.jsx
+++ b/src/frontend/src/pages/Profile.jsx
@@ -229,8 +229,11 @@ export default function Profile() {
         return r.json()
       })
       .then(me => {
-        const routeUserId = Number(profileUserId)
-        const id = Number.isFinite(routeUserId) && routeUserId > 0 ? routeUserId : me.id
+        const routeUserId =
+          typeof profileUserId === 'string' && /^[1-9]\d*$/.test(profileUserId)
+            ? Number.parseInt(profileUserId, 10)
+            : NaN
+        const id = Number.isSafeInteger(routeUserId) && routeUserId > 0 ? routeUserId : me.id
         setCurrentUserId(me.id)
         setUserId(id)
         return Promise.all([

--- a/src/frontend/src/pages/Profile.jsx
+++ b/src/frontend/src/pages/Profile.jsx
@@ -1,5 +1,6 @@
 // src/frontend/src/pages/Profile.jsx
 import { useState, useEffect, useRef, useMemo } from 'react'
+import { useParams } from 'react-router-dom'
 import NavbarComponent from '../Components/Navbar'
 import GameSettings from '../Components/GameSettings'
 import { getAvatarFilter } from '../utils/avatarFilter'
@@ -87,8 +88,10 @@ function emptyHistory(){
 
 export default function Profile() {
   const { auth } = useAuth()
+  const { profileUserId } = useParams()
   const { achievementQueue, dismissAchievement } = useNotifications()
   const [userId, setUserId] = useState(null)
+  const [currentUserId, setCurrentUserId] = useState(null)
   const [profile, setProfile] = useState(null)
   const [paginatedHistory, setPaginatedHistory] = useState(emptyHistory())
   const [userRankData, setUserRankData] = useState(null)
@@ -105,6 +108,7 @@ export default function Profile() {
   const avatarToastTimer = useRef(null)
   const [xpData, setXpData] = useState(null)
   const [achievements, setAchievements] = useState([])
+  const isOwnProfile = userId !== null && currentUserId !== null && userId === currentUserId
 
   useEffect(() => {
     return () => {
@@ -142,6 +146,7 @@ export default function Profile() {
   }
 
   const handleAvatarPick = (e) => {
+    if (!isOwnProfile) return
     const file = e.target.files?.[0]
     e.target.value = ''
     if (!file) return
@@ -158,7 +163,7 @@ export default function Profile() {
   }
 
   const handleAvatarUpload = async () => {
-    if (!avatarFile || avatarBusy) return
+    if (!isOwnProfile || !avatarFile || avatarBusy) return
     setAvatarBusy(true)
     try {
       const formData = new FormData()
@@ -190,7 +195,7 @@ export default function Profile() {
   }
 
   const handleAvatarDelete = async () => {
-    if (avatarBusy) return
+    if (!isOwnProfile || avatarBusy) return
     setAvatarBusy(true)
     try {
       const response = await apiCall('/api/users/avatar', { method: 'DELETE' })
@@ -224,7 +229,9 @@ export default function Profile() {
         return r.json()
       })
       .then(me => {
-        const id = me.id
+        const routeUserId = Number(profileUserId)
+        const id = Number.isFinite(routeUserId) && routeUserId > 0 ? routeUserId : me.id
+        setCurrentUserId(me.id)
         setUserId(id)
         return Promise.all([
           apiCall(`/api/users/profile/${id}`, { signal }).then(r => {
@@ -272,7 +279,7 @@ export default function Profile() {
       })
 
     return () => controller.abort()
-  }, [auth.access_token])
+  }, [auth.access_token, profileUserId])
 
   const handleChange = (e) => {
     const { name, value, type, checked } = e.target
@@ -289,6 +296,7 @@ export default function Profile() {
 
   const handleSave = async (e) => {
     e.preventDefault()
+    if (!isOwnProfile) return
     try {
       const response = await apiCall(`/api/users/profile/${userId}`, {
         method: 'PUT',
@@ -340,17 +348,19 @@ export default function Profile() {
       <NavbarComponent />
       <main className="arcade-content profile-page">
         <div className="profile-layout">
-          <div className="profile-sidebar-col">
-            <FriendsSidebar
-              userId={userId}
-              username={profile?.username}
-              currentUser={{
-                id: userId,
-                username: profile?.username,
-                avatarUrl: profile?.avatarUrl,
-              }}
-            />
-          </div>
+          {isOwnProfile && (
+            <div className="profile-sidebar-col">
+              <FriendsSidebar
+                userId={currentUserId}
+                username={profile?.username}
+                currentUser={{
+                  id: currentUserId,
+                  username: profile?.username,
+                  avatarUrl: profile?.avatarUrl,
+                }}
+              />
+            </div>
+          )}
           <div className="profile-main-col">
             <div className="arcade-screen profile-card">
               {avatarToast && (
@@ -387,56 +397,60 @@ export default function Profile() {
                         <span className="profile-spinner" />
                       </div>
                     )}
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      accept="image/*"
-                      className="profile-avatar-file-input"
-                      onChange={handleAvatarPick}
-                      aria-label="Choose avatar image"
-                    />
-                    <div className="profile-avatar-actions">
-                      {!avatarPreview && (
-                        <>
-                          <button
-                            type="button"
-                            className="arcade-btn arcade-btn-secondary profile-avatar-btn"
-                            onClick={() => fileInputRef.current?.click()}
-                            disabled={avatarBusy}
-                          >
-                            Change avatar
-                          </button>
-                          <button
-                            type="button"
-                            className="arcade-btn arcade-btn-danger profile-avatar-btn"
-                            onClick={handleAvatarDelete}
-                            disabled={avatarBusy || !profile?.avatarUrl || profile.avatarUrl === PLACEHOLDER_AVATAR}
-                          >
-                            Remove
-                          </button>
-                        </>
-                      )}
-                      {avatarPreview && (
-                        <>
-                          <button
-                            type="button"
-                            className="arcade-btn arcade-btn-primary profile-avatar-btn"
-                            onClick={handleAvatarUpload}
-                            disabled={avatarBusy}
-                          >
-                            {avatarBusy ? 'Uploading…' : 'Confirm upload'}
-                          </button>
-                          <button
-                            type="button"
-                            className="arcade-btn arcade-btn-secondary profile-avatar-btn"
-                            onClick={clearAvatarSelection}
-                            disabled={avatarBusy}
-                          >
-                            Cancel
-                          </button>
-                        </>
-                      )}
-                    </div>
+                    {isOwnProfile && (
+                      <>
+                        <input
+                          ref={fileInputRef}
+                          type="file"
+                          accept="image/*"
+                          className="profile-avatar-file-input"
+                          onChange={handleAvatarPick}
+                          aria-label="Choose avatar image"
+                        />
+                        <div className="profile-avatar-actions">
+                          {!avatarPreview && (
+                            <>
+                              <button
+                                type="button"
+                                className="arcade-btn arcade-btn-secondary profile-avatar-btn"
+                                onClick={() => fileInputRef.current?.click()}
+                                disabled={avatarBusy}
+                              >
+                                Change avatar
+                              </button>
+                              <button
+                                type="button"
+                                className="arcade-btn arcade-btn-danger profile-avatar-btn"
+                                onClick={handleAvatarDelete}
+                                disabled={avatarBusy || !profile?.avatarUrl || profile.avatarUrl === PLACEHOLDER_AVATAR}
+                              >
+                                Remove
+                              </button>
+                            </>
+                          )}
+                          {avatarPreview && (
+                            <>
+                              <button
+                                type="button"
+                                className="arcade-btn arcade-btn-primary profile-avatar-btn"
+                                onClick={handleAvatarUpload}
+                                disabled={avatarBusy}
+                              >
+                                {avatarBusy ? 'Uploading…' : 'Confirm upload'}
+                              </button>
+                              <button
+                                type="button"
+                                className="arcade-btn arcade-btn-secondary profile-avatar-btn"
+                                onClick={clearAvatarSelection}
+                                disabled={avatarBusy}
+                              >
+                                Cancel
+                              </button>
+                            </>
+                          )}
+                        </div>
+                      </>
+                    )}
                   </div>
                 </div>
 
@@ -459,6 +473,7 @@ export default function Profile() {
                 </div>
 
                 {/* Cell (1,0): Preferences (Profile sub-section + Game settings + Dark mode + Save) */}
+                {isOwnProfile && (
                 <div className="profile-grid-cell profile-grid-cell--prefs">
                   <form className="profile-form" onSubmit={handleSave}>
                     {saveStatus && (
@@ -518,6 +533,7 @@ export default function Profile() {
                     </button>
                   </form>
                 </div>
+                )}
 
                 {/* Cell (1,1): Achievements */}
                 <div className="profile-grid-cell profile-grid-cell--ach">

--- a/src/frontend/src/pages/Profile.jsx
+++ b/src/frontend/src/pages/Profile.jsx
@@ -220,6 +220,20 @@ export default function Profile() {
       return
     }
 
+    setLoading(true)
+    setError('')
+    setSaveStatus('')
+    setAvatarFile(null)
+    setAvatarPreview(null)
+    setAvatarBusy(false)
+    setAvatarToast(null)
+    setAvatarVersion(0)
+    setProfile(null)
+    setPaginatedHistory(emptyHistory())
+    setUserRankData(null)
+    setXpData(null)
+    setAchievements([])
+
     const controller = new AbortController()
     const { signal } = controller
 

--- a/src/frontend/src/pages/Profile.test.jsx
+++ b/src/frontend/src/pages/Profile.test.jsx
@@ -1,7 +1,7 @@
 // src/frontend/src/pages/Profile.test.jsx
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import Profile from './Profile'
 
 let mockAuth = { access_token: 'fake-token' }
@@ -115,6 +115,16 @@ function renderProfile() {
   return render(
     <MemoryRouter>
       <Profile />
+    </MemoryRouter>
+  )
+}
+
+function renderProfileRoute(initialEntry) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/profile/:profileUserId" element={<Profile />} />
+      </Routes>
     </MemoryRouter>
   )
 }
@@ -591,6 +601,78 @@ describe('Profile page (general)', () => {
     expect(screen.getByText('3-1')).toBeInTheDocument()
     expect(screen.getByText('0-3')).toBeInTheDocument()
     expect(screen.queryByText(/no matches yet/i)).not.toBeInTheDocument()
+  })
+
+  it('loads a route profile by user id and hides owner-only controls', async () => {
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 1, username: 'alice' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            id: 7,
+            username: 'bruno',
+            display_name: 'Bruno',
+            dark_mode: false,
+            avatar_url: null,
+            bio: 'visitor profile',
+            status: 'online',
+            created_at: '2026-01-01',
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            results: [],
+            summary: { player_id: 7, wins: 2, losses: 1, total_matches: 3 },
+            total: 0,
+            page: 1,
+            per_page: 10,
+            last_page: 1,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            player_stats: {
+              player_id: 7,
+              rank: 4,
+              wins: 2,
+              losses: 1,
+              total_matches: 3,
+            },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ user_id: 7, xp: 50, level: 2, xp_in_level: 50, xp_to_next_level: 100 }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([]), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      )
+
+    renderProfileRoute('/profile/7')
+
+    expect(await screen.findByRole('heading', { name: 'Bruno' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /change avatar/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /save profile/i })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('friends-sidebar')).not.toBeInTheDocument()
+    expect(global.fetch).toHaveBeenCalledWith(
+      '/api/users/profile/7',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
   })
 
   it('Save profile sends PUT with display name, bio and dark mode', async () => {

--- a/src/frontend/src/pages/Search.css
+++ b/src/frontend/src/pages/Search.css
@@ -1,0 +1,119 @@
+.search-page {
+  min-height: 100vh;
+}
+
+.search-panel {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.search-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.search-form {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: min(420px, 100%);
+}
+
+.search-form input {
+  width: 100%;
+  min-height: 52px;
+  padding: 0.75rem 0.9rem;
+  border: 3px solid var(--arcade-border, #3b241d);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #1f1713;
+  font-family: 'VT323', monospace;
+  font-size: 1.2rem;
+}
+
+.search-status,
+.search-summary,
+.search-pagination {
+  color: var(--metal-silver);
+  font-family: 'VT323', monospace;
+  font-size: 1.2rem;
+}
+
+.search-status--error {
+  color: #ef9a9a;
+}
+
+.search-results {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.search-result-row {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  min-height: 68px;
+  padding: 0.75rem 1rem;
+  border: 2px solid rgba(246, 217, 82, 0.45);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--metal-silver);
+  text-decoration: none;
+  transition: background-color 0.16s ease, transform 0.16s ease;
+}
+
+.search-result-row:hover {
+  background: rgba(246, 217, 82, 0.15);
+  transform: translateY(-1px);
+}
+
+.search-result-avatar {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  border: 2px solid #f6d952;
+  border-radius: 50%;
+  object-fit: cover;
+  background: #3b241d;
+}
+
+.search-result-username {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.7rem;
+  line-height: 1.5;
+}
+
+.search-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.search-pagination button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+@media (max-width: 720px) {
+  .search-panel {
+    padding: 1.25rem;
+  }
+
+  .search-header,
+  .search-form,
+  .search-pagination {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .search-form {
+    min-width: 0;
+  }
+}

--- a/src/frontend/src/pages/Search.jsx
+++ b/src/frontend/src/pages/Search.jsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import NavbarComponent from '../Components/Navbar'
+import { apiCall } from '../utils/apiClient'
+import './Search.css'
+
+const PER_PAGE = 10
+
+function emptySearchPage(query) {
+  return {
+    query,
+    results: [],
+    total: 0,
+    page: 1,
+    per_page: PER_PAGE,
+  }
+}
+
+export default function Search() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const query = searchParams.get('q')?.trim() ?? ''
+  const currentPage = Number(searchParams.get('page') ?? '1')
+  const safePage = Number.isFinite(currentPage) && currentPage > 0 ? currentPage : 1
+  const [inputValue, setInputValue] = useState(query)
+  const [pageData, setPageData] = useState(emptySearchPage(query))
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const lastPage = Math.max(1, Math.ceil((pageData.total || 0) / PER_PAGE))
+
+  useEffect(() => {
+    setInputValue(query)
+  }, [query])
+
+  useEffect(() => {
+    if (!query) {
+      setPageData(emptySearchPage(query))
+      setError('')
+      setLoading(false)
+      return undefined
+    }
+
+    const controller = new AbortController()
+    setLoading(true)
+    setError('')
+
+    apiCall(`/api/users/search?q=${encodeURIComponent(query)}&page=${safePage}&per_page=${PER_PAGE}&sort=username`, {
+      signal: controller.signal,
+      skipRefreshOn401: true,
+    })
+      .then(r => {
+        if (!r.ok) throw new Error(`Search failed: ${r.status}`)
+        return r.json()
+      })
+      .then(data => {
+        if (controller.signal.aborted) return
+        setPageData({
+          query,
+          results: Array.isArray(data.results) ? data.results : [],
+          total: Number.isFinite(data.total) ? data.total : 0,
+          page: Number.isFinite(data.page) ? data.page : safePage,
+          per_page: Number.isFinite(data.per_page) ? data.per_page : PER_PAGE,
+        })
+      })
+      .catch(err => {
+        if (err.name !== 'AbortError') {
+          setPageData(emptySearchPage(query))
+          setError('Could not load user search results.')
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false)
+      })
+
+    return () => controller.abort()
+  }, [query, safePage])
+
+  const submitSearch = (event) => {
+    event.preventDefault()
+    const nextQuery = inputValue.trim()
+    if (!nextQuery) return
+    navigate(`/search?q=${encodeURIComponent(nextQuery)}&page=1`)
+  }
+
+  const goToPage = (page) => {
+    if (!query) return
+    navigate(`/search?q=${encodeURIComponent(query)}&page=${page}`)
+  }
+
+  return (
+    <div className="arcade-shell">
+      <NavbarComponent />
+      <main className="arcade-content search-page">
+        <section className="arcade-screen search-panel">
+          <div className="search-header">
+            <div>
+              <span className="arcade-display mb-3">Find players</span>
+              <h1 className="arcade-title mb-2">User search</h1>
+            </div>
+            <form className="search-form" role="search" onSubmit={submitSearch}>
+              <input
+                type="search"
+                aria-label="Search users"
+                value={inputValue}
+                onChange={(event) => setInputValue(event.target.value)}
+                placeholder="Search by username"
+              />
+              <button type="submit" className="arcade-btn arcade-btn-primary">
+                Search
+              </button>
+            </form>
+          </div>
+
+          {!query && (
+            <p className="search-status">Type a username to start searching.</p>
+          )}
+          {query && loading && (
+            <p className="search-status">Loading results...</p>
+          )}
+          {query && !loading && error && (
+            <p className="search-status search-status--error">{error}</p>
+          )}
+          {query && !loading && !error && pageData.results.length === 0 && (
+            <p className="search-status">No users found for "{query}".</p>
+          )}
+
+          {query && !loading && !error && pageData.results.length > 0 && (
+            <>
+              <div className="search-summary">
+                {pageData.total} result{pageData.total === 1 ? '' : 's'} for "{query}"
+              </div>
+              <div className="search-results" aria-label="User search results">
+                {pageData.results.map(user => (
+                  <Link key={user.id} to={`/profile/${user.id}`} className="search-result-row">
+                    <img
+                      src={user.avatar_url || '/avatar_placeholder.jpg'}
+                      alt=""
+                      className="search-result-avatar"
+                    />
+                    <span className="search-result-username">@{user.username}</span>
+                  </Link>
+                ))}
+              </div>
+              <div className="search-pagination" aria-label="Search results pagination">
+                <button
+                  type="button"
+                  className="arcade-btn arcade-btn-secondary"
+                  disabled={pageData.page <= 1}
+                  onClick={() => goToPage(pageData.page - 1)}
+                >
+                  Previous
+                </button>
+                <span>Page {pageData.page} of {lastPage}</span>
+                <button
+                  type="button"
+                  className="arcade-btn arcade-btn-secondary"
+                  disabled={pageData.page >= lastPage}
+                  onClick={() => goToPage(pageData.page + 1)}
+                >
+                  Next
+                </button>
+              </div>
+            </>
+          )}
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/frontend/src/pages/Search.jsx
+++ b/src/frontend/src/pages/Search.jsx
@@ -20,7 +20,8 @@ export default function Search() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const query = searchParams.get('q')?.trim() ?? ''
-  const currentPage = Number(searchParams.get('page') ?? '1')
+  const pageParam = searchParams.get('page')
+  const currentPage = Number.parseInt(pageParam ?? '1', 10)
   const safePage = Number.isFinite(currentPage) && currentPage > 0 ? currentPage : 1
   const [inputValue, setInputValue] = useState(query)
   const [pageData, setPageData] = useState(emptySearchPage(query))

--- a/src/frontend/src/pages/Search.jsx
+++ b/src/frontend/src/pages/Search.jsx
@@ -50,7 +50,6 @@ export default function Search() {
 
     apiCall(`/api/users/search?q=${encodeURIComponent(query)}&page=${safePage}&per_page=${PER_PAGE}&sort=username`, {
       signal: controller.signal,
-      skipRefreshOn401: true,
     })
       .then(r => {
         if (!r.ok) throw new Error(`Search failed: ${r.status}`)

--- a/src/frontend/src/pages/Search.jsx
+++ b/src/frontend/src/pages/Search.jsx
@@ -28,7 +28,9 @@ export default function Search() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
-  const lastPage = Math.max(1, Math.ceil((pageData.total || 0) / PER_PAGE))
+  const effectivePerPage =
+    Number.isFinite(pageData.per_page) && pageData.per_page > 0 ? pageData.per_page : PER_PAGE
+  const lastPage = Math.max(1, Math.ceil((pageData.total || 0) / effectivePerPage))
 
   useEffect(() => {
     setInputValue(query)

--- a/src/frontend/src/pages/Search.test.jsx
+++ b/src/frontend/src/pages/Search.test.jsx
@@ -19,16 +19,18 @@ function renderSearch(initialEntry = '/search?q=ali') {
 
 describe('Search page', () => {
   beforeEach(() => {
-    vi.spyOn(global, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify({
-        results: [
-          { id: 7, username: 'alice', avatar_url: '/avatars/alice.png' },
-          { id: 8, username: 'alicia', avatar_url: null },
-        ],
-        total: 12,
-        page: 1,
-        per_page: 10,
-      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    vi.spyOn(global, 'fetch').mockImplementation(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({
+          results: [
+            { id: 7, username: 'alice', avatar_url: '/avatars/alice.png' },
+            { id: 8, username: 'alicia', avatar_url: null },
+          ],
+          total: 12,
+          page: 1,
+          per_page: 10,
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      )
     )
   })
 

--- a/src/frontend/src/pages/Search.test.jsx
+++ b/src/frontend/src/pages/Search.test.jsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import Search from './Search'
+
+vi.mock('../Components/Navbar', () => ({
+  default: () => <div data-testid="navbar" />,
+}))
+
+function renderSearch(initialEntry = '/search?q=ali') {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/search" element={<Search />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('Search page', () => {
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        results: [
+          { id: 7, username: 'alice', avatar_url: '/avatars/alice.png' },
+          { id: 8, username: 'alicia', avatar_url: null },
+        ],
+        total: 12,
+        page: 1,
+        per_page: 10,
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches users from the q param and renders results', async () => {
+    renderSearch('/search?q=ali')
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/users/search?q=ali&page=1&per_page=10&sort=username',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      )
+    })
+    expect(await screen.findByText('@alice')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /@alice/i })).toHaveAttribute('href', '/profile/7')
+    expect(screen.getByText(/12 results for "ali"/i)).toBeInTheDocument()
+  })
+
+  it('uses pagination buttons to update the page query', async () => {
+    renderSearch('/search?q=ali&page=1')
+
+    const nextButton = await screen.findByRole('button', { name: /^next$/i })
+    fireEvent.click(nextButton)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        '/api/users/search?q=ali&page=2&per_page=10&sort=username',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      )
+    })
+  })
+
+  it('submits a new query from the full search form', async () => {
+    renderSearch('/search?q=ali')
+
+    const input = await screen.findByRole('searchbox', { name: /search users/i })
+    fireEvent.change(input, { target: { value: 'bruno' } })
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }))
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        '/api/users/search?q=bruno&page=1&per_page=10&sort=username',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      )
+    })
+  })
+})

--- a/src/frontend/src/pages/Tournament.test.jsx
+++ b/src/frontend/src/pages/Tournament.test.jsx
@@ -199,6 +199,7 @@ describe('Tournament page realtime sync', () => {
     await screen.findByText(/1 \/ 4 participants/i)
 
     await act(async () => {
+      vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
       document.dispatchEvent(new Event('visibilitychange'))
     })
 


### PR DESCRIPTION
Closes #

Implementei a busca global de usuários no frontend, acessível pela navbar em todas as páginas. A busca agora faz debounce de 300 ms, mostra sugestões no dropdown com avatar e username, permite ir direto ao perfil do usuário e oferece o link para ver todos os resultados na página completa. Também adicionei a tela de busca com paginação e protegi o fluxo de perfil para suportar navegação por user_id, com testes cobrindo os principais cenários.

Closes #225