### PR TITLE
348 bug tournament match results are duplicated and all wo rounds do not advance

### DIFF
--- a/src/backend/game-service/tests/test_tournament_ws.py
+++ b/src/backend/game-service/tests/test_tournament_ws.py
@@ -60,6 +60,7 @@ def clear_ws_state():
     ws_router._waiting_room_timeout_tasks.clear()
     ws_router._waiting_room_timeout_deadline.clear()
     ws_router._tournament_ready_timeout_tasks.clear()
+    ws_router._tournament_ready_timeout_locks.clear()
     yield
 
     for task in list(ws_router._waiting_room_timeout_tasks.values()):
@@ -79,6 +80,7 @@ def clear_ws_state():
     ws_router._waiting_room_timeout_tasks.clear()
     ws_router._waiting_room_timeout_deadline.clear()
     ws_router._tournament_ready_timeout_tasks.clear()
+    ws_router._tournament_ready_timeout_locks.clear()
 
 
 @pytest.fixture
@@ -306,3 +308,51 @@ async def test_tournament_ready_timeout_with_no_ready_players(monkeypatch, seede
     )
     assert timeout_payload["winner_id"] is None
     assert ready_key not in ws_router._tournament_ready
+
+
+@pytest.mark.asyncio
+async def test_tournament_ready_timeouts_for_same_tournament_are_serialized(monkeypatch):
+    tournament_id = 1
+    rows = [
+        SimpleNamespace(id=10, status="in_progress", player1_id=1, player2_id=2),
+        SimpleNamespace(id=11, status="in_progress", player1_id=3, player2_id=4),
+    ]
+    ws_router._tournament_ready[(tournament_id, 10)] = set()
+    ws_router._tournament_ready[(tournament_id, 11)] = set()
+
+    active_calls = 0
+    max_active_calls = 0
+    original_sleep = ws_router.asyncio.sleep
+
+    async def fake_get_tournament_with_participants(_db, _tournament_id):
+        return SimpleNamespace(id=tournament_id), [], rows
+
+    async def fake_record_timeout_result(*, db, tournament_id, tournament_match_id, winner_id):
+        nonlocal active_calls, max_active_calls
+        active_calls += 1
+        max_active_calls = max(max_active_calls, active_calls)
+        await original_sleep(0)
+        row = next(row for row in rows if row.id == tournament_match_id)
+        row.status = "finished"
+        active_calls -= 1
+        return SimpleNamespace(id=tournament_id), False, []
+
+    async def fake_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(ws_router, "READY_TIMEOUT_SECONDS", 0)
+    monkeypatch.setattr(ws_router, "AsyncSessionLocal", lambda: _NoopSession())
+    monkeypatch.setattr(ws_router, "get_tournament_with_participants", fake_get_tournament_with_participants)
+    monkeypatch.setattr(ws_router, "record_tournament_match_timeout_result", fake_record_timeout_result)
+    monkeypatch.setattr(ws_router, "sync_tournament_ready_timeouts", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(ws_router.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(ws_router.manager, "broadcast", AsyncMock())
+
+    await original_sleep(0)
+    await ws_router.asyncio.gather(
+        ws_router._handle_tournament_ready_timeout(tournament_id, 10),
+        ws_router._handle_tournament_ready_timeout(tournament_id, 11),
+    )
+
+    assert max_active_calls == 1
+    assert [row.status for row in rows] == ["finished", "finished"]

--- a/src/backend/game-service/tests/test_tournament_ws.py
+++ b/src/backend/game-service/tests/test_tournament_ws.py
@@ -176,6 +176,24 @@ def test_tournament_websocket_emits_match_start_when_both_players_ready(monkeypa
         assert "game_room_id" in match_start
 
 
+def test_waiting_room_remembers_existing_match_id_from_first_ready():
+    game_id = "tournament-1-match-99"
+
+    first_ready_payload = {"type": "player_ready", "match_id": 99}
+    second_ready_payload = {"type": "player_ready", "match_id": None}
+
+    assert ws_router._remember_existing_match_id(game_id, first_ready_payload) == 99
+    assert ws_router._remember_existing_match_id(game_id, second_ready_payload) == 99
+    assert ws_router._match_ids[game_id] == 99
+
+
+def test_waiting_room_recovers_tournament_match_id_from_game_room_id():
+    game_id = "tournament-1-match-99"
+
+    assert ws_router._remember_existing_match_id(game_id, {"type": "game_start"}) == 99
+    assert ws_router._match_ids[game_id] == 99
+
+
 @pytest.mark.timeout(10)
 def test_tournament_websocket_rejects_non_participant(monkeypatch, seeded_tournament):
     _patch_auth_and_tournament(monkeypatch, seeded_tournament, include_non_participant=True)

--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -56,6 +56,7 @@ _tournament_ready_timeout_tasks: dict[tuple[int, int], asyncio.Task] = {}
 
 READY_TIMEOUT_SECONDS = 90
 _INVITE_ROOM_ID_RE = re.compile(r"^invite-(\d+)-(\d+)-")
+_TOURNAMENT_GAME_ROOM_ID_RE = re.compile(r"^tournament-\d+-match-(\d+)$")
 
 
 def _bind_match(game_id: str, match_id: int) -> None:
@@ -594,6 +595,19 @@ async def _ensure_game_session(
         pass  # best-effort
 
 
+def _remember_existing_match_id(game_id: str, payload: dict) -> int | None:
+    existing_match_id = payload.get("match_id")
+    if isinstance(existing_match_id, int) and existing_match_id > 0:
+        _match_ids.setdefault(game_id, existing_match_id)
+        return _match_ids.get(game_id)
+
+    tournament_room_match = _TOURNAMENT_GAME_ROOM_ID_RE.match(game_id)
+    if tournament_room_match:
+        _match_ids.setdefault(game_id, int(tournament_room_match.group(1)))
+
+    return _match_ids.get(game_id)
+
+
 def _infer_waiting_room_players(
     game_id: str,
     payload: dict,
@@ -1053,6 +1067,7 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
 
                 ready_set = _waiting_room_ready.setdefault(game_id, set())
                 ready_set.add(player_id)
+                remembered_match_id = _remember_existing_match_id(game_id, data)
 
                 player1_id, player2_id = _infer_waiting_room_players(game_id, data, ready_set)
                 if player1_id is not None and player2_id is not None:
@@ -1081,7 +1096,7 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
                     _cancel_waiting_room_timeout(game_id)
                     existing_match_id = data.get("match_id")
                     if not isinstance(existing_match_id, int):
-                        existing_match_id = _match_ids.get(game_id)
+                        existing_match_id = remembered_match_id
 
                     await _ensure_game_session(
                         game_id,
@@ -1165,9 +1180,7 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
                 if player_id not in (player1_id, player2_id):
                     continue
 
-                existing_match_id = data.get("match_id")
-                if not isinstance(existing_match_id, int):
-                    existing_match_id = _match_ids.get(game_id)
+                existing_match_id = _remember_existing_match_id(game_id, data)
 
                 await _ensure_game_session(
                     game_id,

--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -203,11 +203,24 @@ def _cancel_waiting_room_timeout(game_id: str) -> None:
 def _remove_tournament_ready_state(ready_key: tuple[int, int]) -> None:
     _tournament_ready.pop(ready_key, None)
     _tournament_waiting_rooms.pop(ready_key, None)
+    _maybe_remove_tournament_ready_timeout_lock(ready_key[0])
+
+
+def _maybe_remove_tournament_ready_timeout_lock(tournament_id: int) -> None:
+    has_timeout_tasks = any(
+        key[0] == tournament_id for key in _tournament_ready_timeout_tasks
+    )
+    has_ready_state = any(
+        key[0] == tournament_id for key in _tournament_ready
+    )
+    if not has_timeout_tasks and not has_ready_state:
+        _tournament_ready_timeout_locks.pop(tournament_id, None)
 
 
 def _cancel_tournament_ready_timeout(ready_key: tuple[int, int]) -> None:
     task = _tournament_ready_timeout_tasks.pop(ready_key, None)
     _cancel_task(task)
+    _maybe_remove_tournament_ready_timeout_lock(ready_key[0])
 
 
 def _parse_invite_room_players(game_id: str) -> tuple[int, int] | None:
@@ -453,6 +466,7 @@ async def _handle_tournament_ready_timeout(
                 if tournament_data is None:
                     _remove_tournament_ready_state(ready_key)
                     _tournament_ready_timeout_tasks.pop(ready_key, None)
+                    _maybe_remove_tournament_ready_timeout_lock(tournament_id)
                     return
 
                 _, _, matches = tournament_data
@@ -460,6 +474,7 @@ async def _handle_tournament_ready_timeout(
                 if match_row is None or match_row.status != "in_progress":
                     _remove_tournament_ready_state(ready_key)
                     _tournament_ready_timeout_tasks.pop(ready_key, None)
+                    _maybe_remove_tournament_ready_timeout_lock(tournament_id)
                     return
 
                 players = {match_row.player1_id, match_row.player2_id}
@@ -483,6 +498,7 @@ async def _handle_tournament_ready_timeout(
         except SQLAlchemyError:
             _remove_tournament_ready_state(ready_key)
             _tournament_ready_timeout_tasks.pop(ready_key, None)
+            _maybe_remove_tournament_ready_timeout_lock(tournament_id)
             return
 
         sync_tournament_ready_timeouts(tournament_id, refreshed_matches)
@@ -510,6 +526,7 @@ async def _handle_tournament_ready_timeout(
 
         _remove_tournament_ready_state(ready_key)
         _tournament_ready_timeout_tasks.pop(ready_key, None)
+        _maybe_remove_tournament_ready_timeout_lock(tournament_id)
 
 
 def _schedule_tournament_ready_timeout(tournament_id: int, tournament_match_id: int) -> None:
@@ -1097,15 +1114,11 @@ async def game_websocket(websocket: WebSocket, game_id: str, token: str | None =
 
                 if both_ready:
                     _cancel_waiting_room_timeout(game_id)
-                    existing_match_id = data.get("match_id")
-                    if not isinstance(existing_match_id, int):
-                        existing_match_id = remembered_match_id
-
                     await _ensure_game_session(
                         game_id,
                         player1_id,
                         player2_id,
-                        existing_match_id=existing_match_id,
+                        existing_match_id=remembered_match_id,
                     )
 
                     await manager.broadcast(
@@ -1390,6 +1403,7 @@ def _clear_tournament_ready_for_user(tournament_id: int, user_id: int) -> list[i
     for key in empty_keys:
         _tournament_ready.pop(key, None)
         _tournament_waiting_rooms.pop(key, None)
+        _maybe_remove_tournament_ready_timeout_lock(tournament_id)
 
     return list(affected_match_ids)
 
@@ -1544,6 +1558,7 @@ async def tournament_websocket(
                 if not ready_set:
                     _tournament_ready.pop(ready_key, None)
                     _tournament_waiting_rooms.pop(ready_key, None)
+                    _maybe_remove_tournament_ready_timeout_lock(tournament_id)
 
                 await manager.broadcast(
                     room_id,

--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -53,6 +53,7 @@ _waiting_room_tournament_context: dict[str, tuple[int, int, int]] = {}
 _waiting_room_timeout_tasks: dict[str, asyncio.Task] = {}
 _waiting_room_timeout_deadline: dict[str, float] = {}
 _tournament_ready_timeout_tasks: dict[tuple[int, int], asyncio.Task] = {}
+_tournament_ready_timeout_locks: dict[int, asyncio.Lock] = {}
 
 READY_TIMEOUT_SECONDS = 90
 _INVITE_ROOM_ID_RE = re.compile(r"^invite-(\d+)-(\d+)-")
@@ -440,73 +441,75 @@ async def _handle_tournament_ready_timeout(
     except asyncio.CancelledError:
         return
 
-    ready_set = set(_tournament_ready.get(ready_key, set()))
-    timeout_winner: int | None = None
-    match_row = None
+    lock = _tournament_ready_timeout_locks.setdefault(tournament_id, asyncio.Lock())
+    async with lock:
+        ready_set = set(_tournament_ready.get(ready_key, set()))
+        timeout_winner: int | None = None
+        match_row = None
 
-    try:
-        async with AsyncSessionLocal() as db:
-            tournament_data = await get_tournament_with_participants(db, tournament_id)
-            if tournament_data is None:
-                _remove_tournament_ready_state(ready_key)
-                _tournament_ready_timeout_tasks.pop(ready_key, None)
-                return
+        try:
+            async with AsyncSessionLocal() as db:
+                tournament_data = await get_tournament_with_participants(db, tournament_id)
+                if tournament_data is None:
+                    _remove_tournament_ready_state(ready_key)
+                    _tournament_ready_timeout_tasks.pop(ready_key, None)
+                    return
 
-            _, _, matches = tournament_data
-            match_row = next((m for m in matches if int(m.id) == tournament_match_id), None)
-            if match_row is None or match_row.status != "in_progress":
-                _remove_tournament_ready_state(ready_key)
-                _tournament_ready_timeout_tasks.pop(ready_key, None)
-                return
+                _, _, matches = tournament_data
+                match_row = next((m for m in matches if int(m.id) == tournament_match_id), None)
+                if match_row is None or match_row.status != "in_progress":
+                    _remove_tournament_ready_state(ready_key)
+                    _tournament_ready_timeout_tasks.pop(ready_key, None)
+                    return
 
-            players = {match_row.player1_id, match_row.player2_id}
-            valid_ready_players = {pid for pid in ready_set if pid in players}
-            if len(valid_ready_players) == 1:
-                timeout_winner = next(iter(valid_ready_players))
+                players = {match_row.player1_id, match_row.player2_id}
+                valid_ready_players = {pid for pid in ready_set if pid in players}
+                if len(valid_ready_players) == 1:
+                    timeout_winner = next(iter(valid_ready_players))
 
-            try:
-                _, tournament_complete, _ = await record_tournament_match_timeout_result(
-                    db=db,
-                    tournament_id=tournament_id,
-                    tournament_match_id=tournament_match_id,
-                    winner_id=timeout_winner,
-                )
-            except Exception:
-                await db.rollback()
-                tournament_complete = False
+                try:
+                    _, tournament_complete, _ = await record_tournament_match_timeout_result(
+                        db=db,
+                        tournament_id=tournament_id,
+                        tournament_match_id=tournament_match_id,
+                        winner_id=timeout_winner,
+                    )
+                except Exception:
+                    await db.rollback()
+                    tournament_complete = False
 
-            refreshed = await get_tournament_with_participants(db, tournament_id)
-            refreshed_matches = refreshed[2] if refreshed is not None else []
-    except SQLAlchemyError:
-        _remove_tournament_ready_state(ready_key)
-        _tournament_ready_timeout_tasks.pop(ready_key, None)
-        return
+                refreshed = await get_tournament_with_participants(db, tournament_id)
+                refreshed_matches = refreshed[2] if refreshed is not None else []
+        except SQLAlchemyError:
+            _remove_tournament_ready_state(ready_key)
+            _tournament_ready_timeout_tasks.pop(ready_key, None)
+            return
 
-    sync_tournament_ready_timeouts(tournament_id, refreshed_matches)
+        sync_tournament_ready_timeouts(tournament_id, refreshed_matches)
 
-    room_id = f"tournament_{tournament_id}"
-    await manager.broadcast(
-        room_id,
-        {
-            "type": "match_ready_timeout",
-            "tournament_id": tournament_id,
-            "match_id": tournament_match_id,
-            "winner_id": timeout_winner,
-            "timeout_seconds": READY_TIMEOUT_SECONDS,
-        },
-    )
-    await manager.broadcast(
-        room_id,
-        {"type": "tournament_updated", "tournament_id": tournament_id},
-    )
-    if tournament_complete:
+        room_id = f"tournament_{tournament_id}"
         await manager.broadcast(
             room_id,
-            {"type": "tournament_complete", "tournament_id": tournament_id},
+            {
+                "type": "match_ready_timeout",
+                "tournament_id": tournament_id,
+                "match_id": tournament_match_id,
+                "winner_id": timeout_winner,
+                "timeout_seconds": READY_TIMEOUT_SECONDS,
+            },
         )
+        await manager.broadcast(
+            room_id,
+            {"type": "tournament_updated", "tournament_id": tournament_id},
+        )
+        if tournament_complete:
+            await manager.broadcast(
+                room_id,
+                {"type": "tournament_complete", "tournament_id": tournament_id},
+            )
 
-    _remove_tournament_ready_state(ready_key)
-    _tournament_ready_timeout_tasks.pop(ready_key, None)
+        _remove_tournament_ready_state(ready_key)
+        _tournament_ready_timeout_tasks.pop(ready_key, None)
 
 
 def _schedule_tournament_ready_timeout(tournament_id: int, tournament_match_id: int) -> None:

--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -618,12 +618,13 @@ async def _ensure_game_session(
 def _remember_existing_match_id(game_id: str, payload: dict) -> int | None:
     existing_match_id = payload.get("match_id")
     if isinstance(existing_match_id, int) and existing_match_id > 0:
-        _match_ids.setdefault(game_id, existing_match_id)
+        if game_id not in _match_ids:
+            _bind_match(game_id, existing_match_id)
         return _match_ids.get(game_id)
 
     tournament_room_match = _TOURNAMENT_GAME_ROOM_ID_RE.match(game_id)
-    if tournament_room_match:
-        _match_ids.setdefault(game_id, int(tournament_room_match.group(1)))
+    if tournament_room_match and game_id not in _match_ids:
+        _bind_match(game_id, int(tournament_room_match.group(1)))
 
     return _match_ids.get(game_id)
 

--- a/src/frontend/src/Components/PongCanvasMultiplayer.jsx
+++ b/src/frontend/src/Components/PongCanvasMultiplayer.jsx
@@ -27,6 +27,7 @@ function PongCanvasMultiplayer(props) {
   const gameId = props?.gameId || 'default-game'
   const player1Id = props?.player1Id
   const player2Id = props?.player2Id
+  const matchId = props?.matchId
   const onGameEnd = props?.onGameEnd || (() => { })
   const spectator = Boolean(props?.spectator)
   const onSpectatorCount = props?.onSpectatorCount || (() => { })
@@ -110,11 +111,13 @@ function PongCanvasMultiplayer(props) {
       // Spectators must NOT send game_start — server's spectator branch closes
       // 4003 on any inbound message. Players still need it to bootstrap.
       if (!spectator) {
-        ws.send(JSON.stringify({
+        const startPayload = {
           type: 'game_start',
           player1_id: parseInt(player1Id, 10),
           player2_id: parseInt(player2Id, 10),
-        }))
+        }
+        if (matchId) startPayload.match_id = parseInt(matchId, 10)
+        ws.send(JSON.stringify(startPayload))
       }
     }
 

--- a/src/frontend/src/pages/GamePage.jsx
+++ b/src/frontend/src/pages/GamePage.jsx
@@ -273,6 +273,7 @@ export default function GamePage() {
                   gameId={roomId}
                   player1Id={player1Id}
                   player2Id={player2Id}
+                  matchId={matchId}
                   onGameEnd={handleGameEnd}
                   spectator={isSpectator}
                   onSpectatorCount={setSpectatorCount}

--- a/src/frontend/src/pages/Tournament.test.jsx
+++ b/src/frontend/src/pages/Tournament.test.jsx
@@ -67,11 +67,6 @@ function renderTournamentPage() {
 }
 
 describe('Tournament page realtime sync', () => {
-  const originalVisibilityState = Object.getOwnPropertyDescriptor(
-    Document.prototype,
-    'visibilityState',
-  )
-
   beforeEach(() => {
     wsHandlers = {}
     mockWsClient.send.mockClear()
@@ -82,11 +77,6 @@ describe('Tournament page realtime sync', () => {
 
   afterEach(() => {
     vi.useRealTimers()
-    if (originalVisibilityState) {
-      Object.defineProperty(Document.prototype, 'visibilityState', originalVisibilityState)
-    } else {
-      delete Document.prototype.visibilityState
-    }
   })
 
   it('refreshes tournament data when websocket sends tournament_updated', async () => {
@@ -184,12 +174,6 @@ describe('Tournament page realtime sync', () => {
     const firstTournament = makeTournament([1])
     const secondTournament = makeTournament([1, 2])
     let tournamentReads = 0
-    let visibilityState = 'hidden'
-
-    Object.defineProperty(Document.prototype, 'visibilityState', {
-      configurable: true,
-      get: () => visibilityState,
-    })
 
     apiCall.mockImplementation(async (url) => {
       if (url === '/api/users/auth/me') {
@@ -214,7 +198,6 @@ describe('Tournament page realtime sync', () => {
 
     await screen.findByText(/1 \/ 4 participants/i)
 
-    visibilityState = 'visible'
     await act(async () => {
       vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
       document.dispatchEvent(new Event('visibilitychange'))

--- a/src/frontend/src/pages/Tournament.test.jsx
+++ b/src/frontend/src/pages/Tournament.test.jsx
@@ -198,10 +198,14 @@ describe('Tournament page realtime sync', () => {
 
     await screen.findByText(/1 \/ 4 participants/i)
 
-    await act(async () => {
-      vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
-      document.dispatchEvent(new Event('visibilitychange'))
-    })
+    const visibilitySpy = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible')
+    try {
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+    } finally {
+      visibilitySpy.mockRestore()
+    }
 
     await waitFor(() => {
       expect(screen.getByText(/2 \/ 4 participants/i)).toBeInTheDocument()


### PR DESCRIPTION
## Summary

Fixes two tournament flow bugs:

- tournament matches were creating duplicate match history rows;
- tournaments could get stuck when all active matches timed out by WO with no ready players.

## Root Causes

### Duplicate tournament match history

Tournament matches already create a base `Match` when the tournament assigns an active match.

However, after players left the waiting room and navigated into the actual game page, the in-memory `_match_ids` entry could be cleared during WebSocket cleanup. The game WebSocket then received `game_start` without a known `match_id`, so it created a new `Match` for the same tournament pairing.

That caused duplicate rows in match history/statistics for tournament games.

### Tournament stuck after all active WOs

When multiple active tournament matches timed out at the same time, their ready-timeout handlers ran concurrently.

Each timeout marked one match as finished, but while the other match still appeared `in_progress`, `_assign_available_tournament_matches` still saw those players as busy. As a result, no pending matches were assigned.

Later, a manual withdraw retriggered assignment after state had settled, which is why the tournament appeared to “unstick” only after someone left.

## Changes

- Reused the existing tournament `match_id` for game sessions instead of creating a new base match.
- Recovered tournament match IDs from tournament game room IDs when needed.
- Serialized tournament ready-timeout handling per `tournament_id`.
- Added tests covering:
  - remembering/recovering existing tournament match IDs;
  - concurrent ready timeouts for the same tournament being processed one at a time.

## Validation

- Verified the duplicate match-history issue no longer reproduces.
- Verified tournament advances after all active matches timeout by WO/no ready players.
- Ran syntax validation and diff checks.


Closes #348