### PR TITLE
fix(chat): persist public rooms and refresh lobby state

### DIFF
--- a/src/backend/chat-service/main.py
+++ b/src/backend/chat-service/main.py
@@ -15,7 +15,7 @@ from service.ws.router import router as ws_router, manager
 from service.persistence import (
     get_or_create_dm_room,
     block_user, unblock_user, get_blocked_ids,
-    create_general_room, list_live_rooms,
+    create_general_room, list_public_rooms,
 )
 
 _ALGORITHM = "HS256"
@@ -192,9 +192,9 @@ async def create_room(body: RoomCreate, session: SessionDep, caller: CallerUser)
 
 
 @app.get("/rooms", status_code=200)
-async def get_live_rooms(session: SessionDep, caller: CallerUser):
+async def get_public_rooms(session: SessionDep, caller: CallerUser):
     """List persisted public chat rooms with their active WebSocket connection count."""
-    return await list_live_rooms(session, manager)
+    return await list_public_rooms(session, manager)
 
 
 @app.get("/room/{room_slug}/active")

--- a/src/backend/chat-service/main.py
+++ b/src/backend/chat-service/main.py
@@ -193,7 +193,7 @@ async def create_room(body: RoomCreate, session: SessionDep, caller: CallerUser)
 
 @app.get("/rooms", status_code=200)
 async def get_live_rooms(session: SessionDep, caller: CallerUser):
-    """List all general rooms with at least one active WebSocket connection."""
+    """List persisted public chat rooms with their active WebSocket connection count."""
     return await list_live_rooms(session, manager)
 
 

--- a/src/backend/chat-service/persistence.py
+++ b/src/backend/chat-service/persistence.py
@@ -174,8 +174,11 @@ async def create_general_room(
 
 
 async def list_live_rooms(db: AsyncSession, manager) -> list[dict]:
-    """Return all general rooms that have at least one stored message AND at least one active
-    WebSocket connection — enforcing both conditions from the #209 visibility spec."""
+    """Return all persisted general rooms that have at least one stored message.
+
+    The active WebSocket count is included for display only; it must not decide
+    whether a room exists in the lobby.
+    """
     has_message = exists().where(Message.room_id == ChatRoom.id)
     result = await db.execute(
         select(ChatRoom).where(
@@ -184,9 +187,8 @@ async def list_live_rooms(db: AsyncSession, manager) -> list[dict]:
         )
     )
     rooms = result.scalars().all()
-    live = []
+    rooms_payload = []
     for r in rooms:
         count = manager.active_connections(r.room_name)
-        if count > 0:
-            live.append({"room_name": r.room_name, "active_connections": count})
-    return live
+        rooms_payload.append({"room_name": r.room_name, "active_connections": count})
+    return rooms_payload

--- a/src/backend/chat-service/persistence.py
+++ b/src/backend/chat-service/persistence.py
@@ -12,7 +12,7 @@ from service.models.message import Message
 
 async def get_or_create_room(db: AsyncSession, room_slug: str) -> ChatRoom:
     # NOTE: rooms created here have room_type=NULL (neither "general" nor "dm").
-    # They are intentionally excluded from list_live_rooms (which filters room_type="general").
+    # They are intentionally excluded from public room listings (which filter room_type="general").
     # This path is used by the WebSocket router for direct-URL room access.
     result = await db.execute(select(ChatRoom).where(ChatRoom.room_name == room_slug))
     room = result.scalars().first()
@@ -173,7 +173,7 @@ async def create_general_room(
     return room
 
 
-async def list_live_rooms(db: AsyncSession, manager) -> list[dict]:
+async def list_public_rooms(db: AsyncSession, manager) -> list[dict]:
     """Return all persisted general rooms that have at least one stored message.
 
     The active WebSocket count is included for display only; it must not decide
@@ -192,3 +192,8 @@ async def list_live_rooms(db: AsyncSession, manager) -> list[dict]:
         count = manager.active_connections(r.room_name)
         rooms_payload.append({"room_name": r.room_name, "active_connections": count})
     return rooms_payload
+
+
+async def list_live_rooms(db: AsyncSession, manager) -> list[dict]:
+    """Backward-compatible alias for the previous public-room listing name."""
+    return await list_public_rooms(db, manager)

--- a/src/backend/chat-service/tests/test_main.py
+++ b/src/backend/chat-service/tests/test_main.py
@@ -284,12 +284,12 @@ async def test_post_rooms_propagates_409_for_duplicate_name():
 
 
 # --------------------------------------------------------------------------- #
-# GET /rooms  — list live general rooms
+# GET /rooms  — list persisted general rooms
 # --------------------------------------------------------------------------- #
 
 @pytest.mark.asyncio
 async def test_get_rooms_returns_list_from_persistence():
-    """Endpoint forwards whatever list_live_rooms returns."""
+    """Endpoint forwards persisted rooms and their active counts."""
     session = _make_session()
     _override_db(session)
     fake_rooms = [
@@ -310,7 +310,7 @@ async def test_get_rooms_returns_list_from_persistence():
 
 
 @pytest.mark.asyncio
-async def test_get_rooms_returns_empty_list_when_no_live_rooms():
+async def test_get_rooms_returns_empty_list_when_no_rooms():
     session = _make_session()
     _override_db(session)
     try:

--- a/src/backend/chat-service/tests/test_main.py
+++ b/src/backend/chat-service/tests/test_main.py
@@ -6,7 +6,7 @@ Covers the endpoints NOT already tested by test_service.py:
   - DELETE /block/{user_id}
   - GET /blocked
   - POST /rooms (create_room)
-  - GET /rooms (list_live_rooms)
+  - GET /rooms (list_public_rooms)
   - GET /room/{room_slug}/active
 
 The /dm/{friend_id} endpoint is covered by test_service.py.
@@ -297,7 +297,7 @@ async def test_get_rooms_returns_list_from_persistence():
         {"room_name": "general-2", "active_connections": 1},
     ]
     try:
-        with patch("main.list_live_rooms", new=AsyncMock(return_value=fake_rooms)):
+        with patch("main.list_public_rooms", new=AsyncMock(return_value=fake_rooms)):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                 resp = await client.get(
                     "/rooms",
@@ -314,7 +314,7 @@ async def test_get_rooms_returns_empty_list_when_no_rooms():
     session = _make_session()
     _override_db(session)
     try:
-        with patch("main.list_live_rooms", new=AsyncMock(return_value=[])):
+        with patch("main.list_public_rooms", new=AsyncMock(return_value=[])):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                 resp = await client.get(
                     "/rooms",

--- a/src/backend/chat-service/tests/test_persistence.py
+++ b/src/backend/chat-service/tests/test_persistence.py
@@ -247,7 +247,7 @@ class TestCreateGeneralRoom:
     @pytest.mark.asyncio
     async def test_room_creation_saves_system_message(self, db):
         """The contract says a system 'created by …' message is saved so the
-        new room is immediately visible to list_live_rooms."""
+        new room is immediately visible to the room list."""
         import time
         name = f"r2-room-sys-{int(time.time() * 1000) % 100000}"
         room = await create_general_room(db, name, "alice")

--- a/src/backend/chat-service/tests/test_service.py
+++ b/src/backend/chat-service/tests/test_service.py
@@ -443,15 +443,15 @@ async def test_create_general_room_rejects_invalid_name(db):
 
 
 @pytest.mark.asyncio
-async def test_list_live_rooms_returns_active_only(db):
+async def test_list_live_rooms_returns_persisted_rooms_even_when_empty(db):
     await create_general_room(db, room_name="live", creator_name="alice")
     await create_general_room(db, room_name="empty-room", creator_name="bob")
     mock_manager = MagicMock()
     mock_manager.active_connections.side_effect = lambda slug: 2 if slug == "live" else 0
     result = await list_live_rooms(db, mock_manager)
-    assert len(result) == 1
-    assert result[0]["room_name"] == "live"
-    assert result[0]["active_connections"] == 2
+    rooms = {room["room_name"]: room for room in result}
+    assert rooms["live"]["active_connections"] == 2
+    assert rooms["empty-room"]["active_connections"] == 0
 
 
 @pytest.mark.asyncio

--- a/src/backend/chat-service/tests/test_service.py
+++ b/src/backend/chat-service/tests/test_service.py
@@ -13,7 +13,7 @@ from main import app
 from persistence import get_or_create_room, save_message, get_room_history
 from persistence import block_user, unblock_user, get_blocked_ids, is_blocked
 from persistence import get_or_create_dm_room
-from persistence import create_general_room, list_live_rooms
+from persistence import create_general_room, list_public_rooms
 
 @pytest_asyncio.fixture
 async def db():
@@ -443,24 +443,24 @@ async def test_create_general_room_rejects_invalid_name(db):
 
 
 @pytest.mark.asyncio
-async def test_list_live_rooms_returns_persisted_rooms_even_when_empty(db):
+async def test_list_public_rooms_returns_persisted_rooms_even_when_empty(db):
     await create_general_room(db, room_name="live", creator_name="alice")
     await create_general_room(db, room_name="empty-room", creator_name="bob")
     mock_manager = MagicMock()
     mock_manager.active_connections.side_effect = lambda slug: 2 if slug == "live" else 0
-    result = await list_live_rooms(db, mock_manager)
+    result = await list_public_rooms(db, mock_manager)
     rooms = {room["room_name"]: room for room in result}
     assert rooms["live"]["active_connections"] == 2
     assert rooms["empty-room"]["active_connections"] == 0
 
 
 @pytest.mark.asyncio
-async def test_list_live_rooms_excludes_dm_rooms(db):
+async def test_list_public_rooms_excludes_dm_rooms(db):
     await create_general_room(db, room_name="general1", creator_name="alice")
     await get_or_create_dm_room(db, user_a_id=10, user_b_id=20)
     mock_manager = MagicMock()
     mock_manager.active_connections.return_value = 1
-    result = await list_live_rooms(db, mock_manager)
+    result = await list_public_rooms(db, mock_manager)
     names = [r["room_name"] for r in result]
     assert "general1" in names
     assert "DM-10-20" not in names
@@ -527,7 +527,7 @@ async def test_get_rooms_returns_list():
         yield session
     app.dependency_overrides[get_db] = fake_db
     try:
-        with patch("main.list_live_rooms", new=AsyncMock(
+        with patch("main.list_public_rooms", new=AsyncMock(
             return_value=[{"room_name": "general", "active_connections": 3}]
         )):
             async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/src/frontend/src/Components/FriendsSidebar.css
+++ b/src/frontend/src/Components/FriendsSidebar.css
@@ -2,6 +2,7 @@
 
 .friends-sidebar {
   padding: 1rem;
+  margin-top: 3rem;
 }
 
 .friends-sidebar-title {

--- a/src/frontend/src/Components/LobbyPanel.css
+++ b/src/frontend/src/Components/LobbyPanel.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  padding: 1rem;
+  padding: 2rem;
   background: var(--arcade-bg, #1a1a2e);
   border-left: 1px solid var(--arcade-border, #333);
   min-height: calc(100vh - var(--nav-height));
@@ -10,6 +10,7 @@
   overflow-y: auto;
   flex: 1;
   min-width: 0;
+  margin: auto;
 }
 
 .lobby-panel--compact {
@@ -23,7 +24,7 @@
 }
 
 .lobby-panel__title {
-  font-size: 1rem;
+  font-size: 1.25rem;
   font-weight: bold;
   color: var(--arcade-text, #eee);
   margin: 0;

--- a/src/frontend/src/Components/LobbyPanel.jsx
+++ b/src/frontend/src/Components/LobbyPanel.jsx
@@ -1,7 +1,15 @@
 import { useState, useEffect } from 'react'
 import './LobbyPanel.css'
 
-export default function LobbyPanel({ compact = false, onEnter, username, token }) {
+const ROOM_REFRESH_INTERVAL_MS = 5000
+
+export default function LobbyPanel({
+  compact = false,
+  onEnter,
+  username,
+  token,
+  refreshIntervalMs = ROOM_REFRESH_INTERVAL_MS,
+}) {
   const [rooms, setRooms] = useState([])
   const [loading, setLoading] = useState(true)
   const [fetchError, setFetchError] = useState('')
@@ -14,28 +22,49 @@ export default function LobbyPanel({ compact = false, onEnter, username, token }
       setLoading(false)
       return
     }
-    setLoading(true)
-    setFetchError('')
-    const controller = new AbortController()
-    fetch('/api/chat/rooms', {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: controller.signal,
-    })
-      .then(r => {
+
+    const controllers = new Set()
+
+    async function fetchRooms(showLoading = false) {
+      const controller = new AbortController()
+      controllers.add(controller)
+      if (showLoading) {
+        setLoading(true)
+        setFetchError('')
+      }
+      try {
+        const r = await fetch('/api/chat/rooms', {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: controller.signal,
+        })
         if (!r.ok) throw new Error(`HTTP ${r.status}`)
-        return r.json()
-      })
-      .then(data => {
+        const data = await r.json()
         setRooms(data)
-        setLoading(false)
-      })
-      .catch(err => {
+        setFetchError('')
+      } catch (err) {
         if (err.name === 'AbortError') return
-        setFetchError('Could not load rooms. Try refreshing.')
+        if (showLoading) {
+          setFetchError('Could not load rooms. Try refreshing.')
+        } else {
+          console.warn('Could not refresh public rooms:', err)
+        }
+      } finally {
         setLoading(false)
-      })
-    return () => controller.abort()
-  }, [token])
+        controllers.delete(controller)
+      }
+    }
+
+    fetchRooms(true)
+    const intervalId = refreshIntervalMs > 0
+      ? window.setInterval(() => fetchRooms(false), refreshIntervalMs)
+      : null
+
+    return () => {
+      if (intervalId) window.clearInterval(intervalId)
+      controllers.forEach(controller => controller.abort())
+      controllers.clear()
+    }
+  }, [token, refreshIntervalMs])
 
   async function handleCreate(e) {
     e.preventDefault()
@@ -81,7 +110,7 @@ export default function LobbyPanel({ compact = false, onEnter, username, token }
         <p className="lobby-panel__error" role="alert">{fetchError}</p>
       ) : rooms.length === 0 ? (
         <p className="lobby-panel__status">
-          {compact ? 'No public live rooms.' : 'No public live rooms yet. Create the first one!'}
+          {compact ? 'No public rooms.' : 'No public rooms yet. Create the first one!'}
         </p>
       ) : (
         <ul className="lobby-panel__list">

--- a/src/frontend/src/Components/LobbyPanel.jsx
+++ b/src/frontend/src/Components/LobbyPanel.jsx
@@ -23,9 +23,13 @@ export default function LobbyPanel({
       return
     }
 
+    let isMounted = true
+    let latestRequestId = 0
+    let intervalId = null
     const controllers = new Set()
 
     async function fetchRooms(showLoading = false) {
+      const requestId = ++latestRequestId
       const controller = new AbortController()
       controllers.add(controller)
       if (showLoading) {
@@ -39,27 +43,35 @@ export default function LobbyPanel({
         })
         if (!r.ok) throw new Error(`HTTP ${r.status}`)
         const data = await r.json()
+        if (!isMounted || requestId !== latestRequestId) return
         setRooms(data)
         setFetchError('')
       } catch (err) {
         if (err.name === 'AbortError') return
+        if (!isMounted || requestId !== latestRequestId) return
         if (showLoading) {
           setFetchError('Could not load rooms. Try refreshing.')
         } else {
           console.warn('Could not refresh public rooms:', err)
         }
       } finally {
-        setLoading(false)
         controllers.delete(controller)
+        if (isMounted && showLoading && requestId === latestRequestId) {
+          setLoading(false)
+        }
       }
     }
 
-    fetchRooms(true)
-    const intervalId = refreshIntervalMs > 0
-      ? window.setInterval(() => fetchRooms(false), refreshIntervalMs)
-      : null
+    async function startPolling() {
+      await fetchRooms(true)
+      if (!isMounted || refreshIntervalMs <= 0) return
+      intervalId = window.setInterval(() => fetchRooms(false), refreshIntervalMs)
+    }
+
+    startPolling()
 
     return () => {
+      isMounted = false
       if (intervalId) window.clearInterval(intervalId)
       controllers.forEach(controller => controller.abort())
       controllers.clear()

--- a/src/frontend/src/Components/LobbyPanel.test.jsx
+++ b/src/frontend/src/Components/LobbyPanel.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
 import LobbyPanel from './LobbyPanel'
 
 const TOKEN = 'test-token'
@@ -19,8 +19,18 @@ function renderLobby(props = {}) {
   return { onEnter }
 }
 
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
 describe('LobbyPanel', () => {
-  beforeEach(() => vi.restoreAllMocks())
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
 
   it('fetches rooms on mount and renders the list', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValueOnce(
@@ -60,6 +70,7 @@ describe('LobbyPanel', () => {
   })
 
   it('refreshes room counts while the lobby stays mounted', async () => {
+    vi.useFakeTimers()
     vi.spyOn(global, 'fetch')
       .mockResolvedValueOnce(
         new Response(
@@ -74,10 +85,16 @@ describe('LobbyPanel', () => {
         )
       )
 
-    renderLobby({ refreshIntervalMs: 10 })
+    renderLobby({ refreshIntervalMs: 5000 })
 
-    await waitFor(() => expect(screen.getByText('(2)')).toBeInTheDocument())
-    await waitFor(() => expect(screen.getByText('(12)')).toBeInTheDocument())
+    await flushPromises()
+    expect(screen.getByText('(2)')).toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+    await flushPromises()
+    expect(screen.getByText('(12)')).toBeInTheDocument()
   })
 
   it('calls onEnter with room name when a room button is clicked', async () => {

--- a/src/frontend/src/Components/LobbyPanel.test.jsx
+++ b/src/frontend/src/Components/LobbyPanel.test.jsx
@@ -37,14 +37,47 @@ describe('LobbyPanel', () => {
     expect(screen.getByText('gaming')).toBeInTheDocument()
   })
 
-  it('shows empty state when no rooms are live', async () => {
+  it('shows empty state when no public rooms exist', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValueOnce(
       new Response(JSON.stringify([]), { status: 200 })
     )
     renderLobby()
     await waitFor(() =>
-      expect(screen.getByText(/no public live rooms/i)).toBeInTheDocument()
+      expect(screen.getByText(/no public rooms/i)).toBeInTheDocument()
     )
+  })
+
+  it('renders persisted rooms with zero active connections', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify([{ room_name: 'quiet-room', active_connections: 0 }]),
+        { status: 200 }
+      )
+    )
+    renderLobby()
+    await waitFor(() => expect(screen.getByText('quiet-room')).toBeInTheDocument())
+    expect(screen.getByText('(0)')).toBeInTheDocument()
+  })
+
+  it('refreshes room counts while the lobby stays mounted', async () => {
+    vi.spyOn(global, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ room_name: 'busy-room', active_connections: 2 }]),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([{ room_name: 'busy-room', active_connections: 12 }]),
+          { status: 200 }
+        )
+      )
+
+    renderLobby({ refreshIntervalMs: 10 })
+
+    await waitFor(() => expect(screen.getByText('(2)')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('(12)')).toBeInTheDocument())
   })
 
   it('calls onEnter with room name when a room button is clicked', async () => {

--- a/src/frontend/src/pages/Chat.css
+++ b/src/frontend/src/pages/Chat.css
@@ -4,6 +4,7 @@
 
 .chat-view {
   max-width: 700px;
+  margin: auto;
 }
 
 .chat-messages {

--- a/src/frontend/src/pages/Profile.css
+++ b/src/frontend/src/pages/Profile.css
@@ -7,7 +7,7 @@
  */
 
 .profile-page {
-  padding: 3rem 1rem;
+  padding: 1rem;
 }
 
 .profile-card {


### PR DESCRIPTION

Closes #367
Closes #357

## Summary

This PR fixes the chat room persistence issue and improves the lobby refresh behavior.

Previously, newly created chat rooms could disappear after the user changed pages or refreshed the browser because the lobby list depended on rooms with active WebSocket connections. Now, public chat rooms are returned from persisted data even when they have no active connections.

This also updates the lobby panel to refresh the room list automatically while it is mounted, keeping the active user count updated without requiring the user to reload the page.

## Changes

- Return persisted public chat rooms even when `active_connections` is `0`.
- Keep newly created chat rooms visible after page navigation or browser refresh.
- Refresh the lobby panel automatically while it is mounted.
- Keep room participant counts updated when users join or leave.
- Update lobby wording from “live rooms” to “public rooms”.
- Add/update backend tests for persisted chat room behavior.
- Add/update frontend tests for lobby refresh and active user count updates.
