### PR TITLE
Bug fix websocket trying to open when tournament already finished_

### DIFF
--- a/src/frontend/src/pages/Tournament.jsx
+++ b/src/frontend/src/pages/Tournament.jsx
@@ -9,6 +9,11 @@ import './Tournament.css'
 
 const READY_TIMEOUT_SECONDS = 90
 const TOURNAMENT_SYNC_INTERVAL_MS = 3000
+const LIVE_TOURNAMENT_STATUSES = new Set(['open', 'in_progress'])
+
+function isLiveTournamentStatus(status) {
+  return LIVE_TOURNAMENT_STATUSES.has(status)
+}
 
 export default function Tournament() {
   const { id: tournamentId } = useParams()
@@ -135,8 +140,7 @@ export default function Tournament() {
   const isJoined = useMemo(() => {
     if (!currentUser || !tournament) return false
   
-    const isActive =
-      tournament.status === 'open' || tournament.status === 'in_progress'
+    const isActive = isLiveTournamentStatus(tournament.status)
   
     return isActive && tournament.participants?.some(
       (p) => Number(p.user_id) === Number(currentUser.id),
@@ -259,7 +263,7 @@ export default function Tournament() {
     if (!tournamentId || !auth?.access_token) return
 
     const syncTournament = () => {
-      if (tournament?.status !== 'open' && tournament?.status !== 'in_progress') return
+      if (!isLiveTournamentStatus(tournament?.status)) return
       void refreshTournament()
     }
 
@@ -280,6 +284,8 @@ export default function Tournament() {
 
   useEffect(() => {
     if (!tournamentId || !auth?.access_token) return
+    if (!isLiveTournamentStatus(tournament?.status)) return
+    if (!isJoined) return
 
     const scheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
     const url = `${scheme}//${window.location.host}/api/game/ws/tournament/${tournamentId}?token=${auth.access_token}`
@@ -361,7 +367,7 @@ export default function Tournament() {
       setWsConnected(false)
       ws.close()
     }
-  }, [tournamentId, auth?.access_token, handleMatchStart, refreshTournament])
+  }, [tournamentId, auth?.access_token, tournament?.status, isJoined, handleMatchStart, refreshTournament])
 
   async function handleStartTournament() {
     if (!tournamentId || !canStart) return

--- a/src/frontend/src/pages/Tournament.test.jsx
+++ b/src/frontend/src/pages/Tournament.test.jsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import Tournament from './Tournament'
 import { apiCall, apiJson } from '../utils/apiClient'
+import { createWsClient } from '../utils/wsClient'
 
 let wsHandlers = {}
 const mockWsClient = {
@@ -40,13 +41,13 @@ function mockOk(data) {
   }
 }
 
-function makeTournament(participantIds) {
+function makeTournament(participantIds, status = 'open') {
   return {
     id: 99,
     name: 'Spring Cup',
     creator_id: 1,
     max_participants: 4,
-    status: 'open',
+    status,
     created_at: '2026-04-21T00:00:00Z',
     participants: participantIds.map((userId, index) => ({
       user_id: userId,
@@ -106,6 +107,7 @@ describe('Tournament page realtime sync', () => {
     renderTournamentPage()
 
     await screen.findByText(/1 \/ 4 participants/i)
+    await waitFor(() => expect(createWsClient).toHaveBeenCalled())
 
     await act(async () => {
       await wsHandlers.onMessage?.({
@@ -117,6 +119,77 @@ describe('Tournament page realtime sync', () => {
     await waitFor(() => {
       expect(screen.getByText(/2 \/ 4 participants/i)).toBeInTheDocument()
     })
+  })
+
+  it('does not open websocket for completed tournaments', async () => {
+    apiCall.mockImplementation(async (url) => {
+      if (url === '/api/users/auth/me') {
+        return mockOk({ id: 1, username: 'owner' })
+      }
+      if (url === '/api/game/tournaments/99') {
+        return mockOk(makeTournament([1, 2, 3, 4], 'complete'))
+      }
+      if (url.startsWith('/api/users/profile/')) {
+        const userId = url.split('/').pop()
+        return mockOk({ username: `user-${userId}`, display_name: `User ${userId}`, avatar_url: null })
+      }
+      throw new Error(`Unexpected URL in test: ${url}`)
+    })
+
+    renderTournamentPage()
+
+    await screen.findByText(/4 \/ 4 participants/i)
+
+    expect(createWsClient).not.toHaveBeenCalled()
+  })
+
+  it('opens websocket for in-progress tournaments', async () => {
+    apiCall.mockImplementation(async (url) => {
+      if (url === '/api/users/auth/me') {
+        return mockOk({ id: 1, username: 'owner' })
+      }
+      if (url === '/api/game/tournaments/99') {
+        return mockOk(makeTournament([1, 2, 3, 4], 'in_progress'))
+      }
+      if (url.startsWith('/api/users/profile/')) {
+        const userId = url.split('/').pop()
+        return mockOk({ username: `user-${userId}`, display_name: `User ${userId}`, avatar_url: null })
+      }
+      throw new Error(`Unexpected URL in test: ${url}`)
+    })
+
+    renderTournamentPage()
+
+    await screen.findByText(/4 \/ 4 participants/i)
+
+    await waitFor(() => {
+      expect(createWsClient).toHaveBeenCalledWith(
+        expect.stringContaining('/api/game/ws/tournament/99?token=test-token'),
+        expect.any(Object),
+      )
+    })
+  })
+
+  it('does not open websocket for active tournaments when current user is not a participant', async () => {
+    apiCall.mockImplementation(async (url) => {
+      if (url === '/api/users/auth/me') {
+        return mockOk({ id: 9, username: 'former-player' })
+      }
+      if (url === '/api/game/tournaments/99') {
+        return mockOk(makeTournament([1, 2, 3, 4], 'in_progress'))
+      }
+      if (url.startsWith('/api/users/profile/')) {
+        const userId = url.split('/').pop()
+        return mockOk({ username: `user-${userId}`, display_name: `User ${userId}`, avatar_url: null })
+      }
+      throw new Error(`Unexpected URL in test: ${url}`)
+    })
+
+    renderTournamentPage()
+
+    await screen.findByText(/4 \/ 4 participants/i)
+
+    expect(createWsClient).not.toHaveBeenCalled()
   })
 
   it('polls and refreshes participants without websocket events', async () => {
@@ -231,6 +304,7 @@ describe('Tournament page realtime sync', () => {
 
     renderTournamentPage()
     await screen.findByText(/2 \/ 4 participants/i)
+    await waitFor(() => expect(createWsClient).toHaveBeenCalled())
 
     await act(async () => {
       await wsHandlers.onMessage?.({
@@ -263,6 +337,7 @@ describe('Tournament page realtime sync', () => {
 
     renderTournamentPage()
     await screen.findByText(/2 \/ 4 participants/i)
+    await waitFor(() => expect(createWsClient).toHaveBeenCalled())
 
     await act(async () => {
       await wsHandlers.onMessage?.({


### PR DESCRIPTION
Closes #

O que foi corrigido
Quando um jogador desistia de um torneio e voltava para a página do torneio, o frontend tentava abrir um WebSocket que o backend rejeitava com 4003, gerando erro no console.

Raiz do problema
O guard if player_id not in participant_ids estava comentado no backend, deixando não-participantes entrar no WS do torneio.
O frontend não verificava isJoined antes de abrir o WebSocket, tentando conectar mesmo após desistência.
Solução aplicada
backend: Reativado o guard no tournament_websocket (router.py) → rejeita com 4003 usuários fora do torneio.
frontend: Tournament.jsx agora só abre o WS quando:
isJoined === true
status === 'open' ou status === 'in_progress'
testes: Adicionado teste em Tournament.test.jsx para cobrir "usuário não-participante não abre WS".
Resultado
Usuário desiste do torneio → isJoined fica false → WS não abre → sem erro no console.
Usuário ainda vê dados do torneio via HTTP (GET /api/game/tournaments/{id}) — read-only.
Backend mantém proteção: se alguém forçar WS mesmo desistindo, leva 4003 clean.


Closes #401