### PR TITLE
fix: record tournament match results server-side

### DIFF
--- a/src/backend/game-service/tests/test_tournament_ws.py
+++ b/src/backend/game-service/tests/test_tournament_ws.py
@@ -261,6 +261,78 @@ async def test_tournament_ready_timeout_marks_wo_winner(monkeypatch, seeded_tour
 
 
 @pytest.mark.asyncio
+async def test_game_over_records_tournament_match_result_server_side(monkeypatch):
+    game_id = "tournament-2-match-6"
+    tournament_id = 2
+    match_id = 6
+    tournament_match_id = 50
+
+    ws_router._match_ids[game_id] = match_id
+    ws_router._waiting_room_tournament_context[game_id] = (
+        tournament_id,
+        match_id,
+        tournament_match_id,
+    )
+
+    recorded = {}
+
+    async def fake_record_tournament_match_result(
+        db,
+        tournament_id,
+        match_id,
+        winner_id,
+        score_p1,
+        score_p2,
+    ):
+        recorded.update(
+            {
+                "tournament_id": tournament_id,
+                "match_id": match_id,
+                "winner_id": winner_id,
+                "score_p1": score_p1,
+                "score_p2": score_p2,
+            }
+        )
+        return SimpleNamespace(id=tournament_id), True, []
+
+    async def fake_get_tournament_with_participants(_db, _tournament_id):
+        return SimpleNamespace(id=tournament_id), [], []
+
+    monkeypatch.setattr(ws_router, "AsyncSessionLocal", lambda: _NoopSession())
+    monkeypatch.setattr(
+        ws_router,
+        "record_tournament_match_result",
+        fake_record_tournament_match_result,
+    )
+    monkeypatch.setattr(
+        ws_router,
+        "get_tournament_with_participants",
+        fake_get_tournament_with_participants,
+    )
+    monkeypatch.setattr(ws_router.game_manager, "delete_session", AsyncMock())
+    broadcast_mock = AsyncMock()
+    monkeypatch.setattr(ws_router.manager, "broadcast", broadcast_mock)
+
+    await ws_router._on_game_over(game_id, winner_id=4, score_p1=10, score_p2=6)
+
+    assert recorded == {
+        "tournament_id": tournament_id,
+        "match_id": match_id,
+        "winner_id": 4,
+        "score_p1": 10,
+        "score_p2": 6,
+    }
+    tournament_room = f"tournament_{tournament_id}"
+    broadcast_payloads = [
+        call.args[1]
+        for call in broadcast_mock.await_args_list
+        if call.args[0] == tournament_room
+    ]
+    assert {"type": "tournament_updated", "tournament_id": tournament_id} in broadcast_payloads
+    assert {"type": "tournament_complete", "tournament_id": tournament_id} in broadcast_payloads
+
+
+@pytest.mark.asyncio
 async def test_tournament_ready_timeout_with_no_ready_players(monkeypatch, seeded_tournament):
     tournament_id = seeded_tournament["tournament_id"]
     tournament_match_id = seeded_tournament["tournament_match_id"]

--- a/src/backend/game-service/ws/router.py
+++ b/src/backend/game-service/ws/router.py
@@ -15,9 +15,14 @@ from shared.ws.manager import ConnectionManager
 from shared.database import AsyncSessionLocal, get_db
 from shared.logging import ws_logger
 from service.persistence import (
+    InvalidWinner,
+    TournamentMatchAlreadyFinished,
+    TournamentMatchNotFound,
+    TournamentNotFound,
     create_match,
     finish_match,
     get_tournament_with_participants,
+    record_tournament_match_result,
     record_tournament_match_timeout_result,
 )
 from service.game_manager import game_manager
@@ -689,10 +694,30 @@ async def _on_game_over(
     forfeit_reason: str | None = None,
 ) -> None:
     """Server-driven callback when a match naturally ends."""
+    tournament_ctx = _waiting_room_tournament_context.get(game_id)
+    tournament_complete = False
+    tournament_matches = []
     try:
         async with AsyncSessionLocal() as db:
             match_id = _match_ids.get(game_id)
-            if match_id is not None:
+            if match_id is not None and tournament_ctx is not None:
+                tournament_id, tournament_match_db_id, _ = tournament_ctx
+                try:
+                    _, tournament_complete, _ = await record_tournament_match_result(
+                        db,
+                        tournament_id,
+                        tournament_match_db_id,
+                        winner_id,
+                        score_p1,
+                        score_p2,
+                    )
+                    refreshed = await get_tournament_with_participants(db, tournament_id)
+                    tournament_matches = refreshed[2] if refreshed is not None else []
+                except TournamentMatchAlreadyFinished:
+                    pass
+                except (TournamentNotFound, TournamentMatchNotFound, InvalidWinner):
+                    pass
+            elif match_id is not None:
                 # finish_match() now skips XP awarding for AI_PLAYER_ID on
                 # either side (see persistence.py), so the previous AI-bypass
                 # raw-UPDATE path is no longer needed and would skip the
@@ -709,6 +734,21 @@ async def _on_game_over(
     except SQLAlchemyError:
         pass  # best-effort
     finally:
+        if tournament_ctx is not None:
+            tournament_id = tournament_ctx[0]
+            if tournament_matches:
+                sync_tournament_ready_timeouts(tournament_id, tournament_matches)
+            tournament_room = f"tournament_{tournament_id}"
+            await manager.broadcast(
+                tournament_room,
+                {"type": "tournament_updated", "tournament_id": tournament_id},
+            )
+            if tournament_complete:
+                await manager.broadcast(
+                    tournament_room,
+                    {"type": "tournament_complete", "tournament_id": tournament_id},
+                )
+
         # Cancel any in-flight disconnect countdown and await its completion so the
         # countdown coroutine fully exits before we proceed with cleanup.
         # Guard: _on_game_over may be called *from* the countdown task itself

--- a/src/frontend/src/pages/GamePage.jsx
+++ b/src/frontend/src/pages/GamePage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams, useNavigate, useLocation, useSearchParams } from 'react-router-dom'
 import NavbarComponent from '../Components/Navbar'
 import PongCanvasMultiplayer from '../Components/PongCanvasMultiplayer'
@@ -83,7 +83,6 @@ export default function GamePage() {
   const [specPlayer2Id, setSpecPlayer2Id] = useState(null)
   const [gameOverResult, setGameOverResult] = useState(null)
   const [spectatorCount, setSpectatorCount] = useState(0)
-  const submittingRef = useRef(false)
 
   useEffect(() => {
     // Spectators don't have player IDs in location.state — they reach this
@@ -132,20 +131,6 @@ export default function GamePage() {
   if (!isSpectator && isAuthReady && !isAuthenticated) return null
 
   async function handleGameEnd(result) {
-    if (tournamentId && matchId && !submittingRef.current) {
-      submittingRef.current = true
-      try {
-        await apiJson(`/api/game/tournaments/${tournamentId}/matches/${matchId}/result`, {
-          method: 'POST',
-          body: JSON.stringify(result),
-        })
-        // Fall through — show overlay with tournament-specific buttons
-      } catch (error) {
-        console.error('Failed to submit tournament result:', error)
-      } finally {
-        submittingRef.current = false
-      }
-    }
     setGameOverResult(result)
   }
 

--- a/src/frontend/src/pages/GamePage.test.jsx
+++ b/src/frontend/src/pages/GamePage.test.jsx
@@ -66,6 +66,15 @@ const remoteState = {
   opponent:    { id: 2, username: 'Bob',   avatar_url: null },
 }
 
+const tournamentState = {
+  currentUser: { id: 1, username: 'Alice', avatar_url: null },
+  opponent: { id: 2, username: 'Bob', avatar_url: null },
+  player1_id: 1,
+  player2_id: 2,
+  tournamentId: 99,
+  matchId: 7,
+}
+
 describe('GamePage game over overlay', () => {
   beforeEach(() => {
     apiJson.mockRejectedValue(new Error('no server in tests'))
@@ -126,6 +135,9 @@ describe('GamePage game over overlay', () => {
     // João should see YOU LOST, not YOU WON
     expect(await screen.findByRole('heading', { name: /you lost/i })).toBeInTheDocument()
     expect(screen.getByTestId('winner-name').textContent).toBe('João')
+    expect(apiJson.mock.calls.some(([url]) =>
+      url.includes('/api/game/tournaments/99/matches/7/result')
+    )).toBe(false)
   })
 
   it('skips profile fetch for player2 in AI games (player2Id === 0)', async () => {
@@ -150,6 +162,63 @@ describe('GamePage game over overlay', () => {
     await screen.findByRole('heading', { name: /you won/i })
     expect(screen.getByTestId('p1-name').textContent).toBe('alice')
     expect(screen.getByTestId('p2-name').textContent).toBe('bob')
+  })
+
+  it('does not submit tournament results from the game page client', async () => {
+    apiJson.mockImplementation((url) => {
+      if (url.includes('/auth/me')) {
+        return Promise.resolve({ id: 1, username: 'alice', display_name: 'Alice' })
+      }
+      if (url.includes('/profile/')) {
+        return Promise.reject(new Error('profile ignored'))
+      }
+      if (url.includes('/api/game/tournaments/99/matches/7/result')) {
+        return Promise.resolve({})
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`))
+    })
+
+    renderGamePage(tournamentState)
+    await act(async () => {})
+
+    fireEvent.click(screen.getByText('Simulate Game End'))
+
+    expect(await screen.findByRole('heading', { name: /you won/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Simulate Game End'))
+
+    const resultCalls = apiJson.mock.calls.filter(([url]) =>
+      url.includes('/api/game/tournaments/99/matches/7/result')
+    )
+    expect(resultCalls).toHaveLength(0)
+  })
+
+  it('does not submit tournament result from the losing client', async () => {
+    apiJson.mockImplementation((url) => {
+      if (url.includes('/auth/me')) {
+        return Promise.resolve({ id: 2, username: 'bob', display_name: 'Bob' })
+      }
+      if (url.includes('/profile/')) {
+        return Promise.reject(new Error('profile ignored'))
+      }
+      if (url.includes('/api/game/tournaments/99/matches/7/result')) {
+        return Promise.resolve({})
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`))
+    })
+
+    renderGamePage({
+      ...tournamentState,
+      currentUser: { id: 2, username: 'Bob', avatar_url: null },
+    })
+    await act(async () => {})
+
+    fireEvent.click(screen.getByText('Simulate Game End'))
+
+    expect(await screen.findByRole('heading', { name: /you lost/i })).toBeInTheDocument()
+    expect(apiJson.mock.calls.some(([url]) =>
+      url.includes('/api/game/tournaments/99/matches/7/result')
+    )).toBe(false)
   })
 })
 


### PR DESCRIPTION
Closes #


Fixed the tournament result race by moving tournament match result recording to the backend game-over flow.

Previously, both players could receive the same `game_over` event and each client attempted to POST the tournament result, causing one request to succeed and the other to fail with `409 Match already finished`.

Changes:
- Record tournament match results server-side in `_on_game_over` when the game has tournament context.
- Broadcast `tournament_updated` / `tournament_complete` from the backend after recording.
- Remove client-side tournament result POST from `GamePage`.
- Add coverage for backend server-side result recording and frontend no-POST behavior.

Validation:
- `git diff --check` passed.
- Could not run local test suites in this environment because `node` and `pytest` are unavailable.


Closes #394